### PR TITLE
Add people using gluegun section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,15 @@ is the real MVP.
 Or, make your own CLI and just use parts of `gluegun` for what you need.
 
 
+### People Using Gluegun
+
+Who's gluing apps together with gluegun?  You can see this tool in action with 
+the following victims... technologies.
+
+* [Reactotron](https://github.com/reactotron/reactotron) - App for React App Inspection
+* [Ignite](https://github.com/infinitered/ignite) - React Native Headstarter
+* ...next?
+
 ### Under Construction
 
 We're just getting started.


### PR DESCRIPTION
Attempt at placing "who's using" section, with the same vibe and cadence of the readme.  Eventually this will link to a `/docs` markdown file with a table layout to avoid merge conflicts and README clutter.

closes #13