### PR TITLE
Changes meta tags & removes command functionName & extension description

### DIFF
--- a/docs/creating-plugins.md
+++ b/docs/creating-plugins.md
@@ -30,23 +30,21 @@ At the top of these `*.js` files you have the ability to customize some meta dat
 For example, you might have a command called `commands/say.js` that looks like this:
 
 ```js
-// @command     say
-// @description This command will say the word you tell it to.
+// @cliCommand     say
+// @cliDescription This command will say the word you tell it to.
 module.exports = async function (context) {
   const { print, parameters } = context  
   print.info(`hello ${parameters.first}`)
 }
 ```
 
-This `@command` and the `@description` will be detected and will populate the information that
+This `@cliCommand` and the `@cliDescription` will be detected and will populate the information that
 the user sees when they ask for help or a list of commands.
 
-Extensions are similar.
+Extensions are similar except they use the `@contextExtension` 
 
 ```js
-// @extension   appstore
-// @description Finds out information about the products on the AppStore.
-
+// @contextExtension   appstore
 module.exports = function (plugin, command, context) {
 
   async function getAppDetails (productId) {

--- a/packages/gluegun-patching/extensions/patching.js
+++ b/packages/gluegun-patching/extensions/patching.js
@@ -1,11 +1,9 @@
-// @extension patching
-// @description Provides textfile patching functionality
+// @contextExtension patching
 
 // TODO: migrate to jetpack
 const fs = require('fs')
 /**
- * @extension patching
- * @description Provides textfile patching functionality
+ * @contextExtension patching
  *
  * @param  {Plugin}     plugin  The plugin that triggered.
  * @param  {Command}    command The current command that is running.

--- a/packages/gluegun/src/domain/command.js
+++ b/packages/gluegun/src/domain/command.js
@@ -27,7 +27,6 @@ class Command {
     this.name = null
     this.description = null
     this.file = null
-    this.function = null
     this.run = null
     this.loadState = 'none'
     this.errorState = 'none'

--- a/packages/gluegun/src/loaders/extension-loader.js
+++ b/packages/gluegun/src/loaders/extension-loader.js
@@ -67,7 +67,6 @@ function loadFromFile (file) {
 
     // let's override if we've found these tokens
     extension.name = tokens.extension || extension.name
-    extension.description = tokens.description || extension.description
 
     // require in the module -- best chance to bomb is here
     const extensionModule = loadModule(file)

--- a/packages/gluegun/src/loaders/toml-plugin-loader.js
+++ b/packages/gluegun/src/loaders/toml-plugin-loader.js
@@ -66,8 +66,8 @@ function loadFromDirectory (directory, options = {}) {
     // also load commands located in the commands key
     const commandsFromConfig = map(
       config => {
-        const { name, file, functionName, description } = config
-        const command = loadCommandFromFile(`${directory}/${file}`, functionName)
+        const { name, file, description } = config
+        const command = loadCommandFromFile(`${directory}/${file}`)
         command.name = name
         command.description = description
         return command

--- a/packages/gluegun/test/domain/command-test.js
+++ b/packages/gluegun/test/domain/command-test.js
@@ -5,7 +5,6 @@ test('default state', t => {
   const command = new Command()
   t.truthy(command)
   t.falsy(command.name)
-  t.falsy(command.functionName)
   t.falsy(command.file)
   t.falsy(command.description)
   t.falsy(command.run)

--- a/packages/gluegun/test/fixtures/good-apps/basic/inapp/commands/hello.js
+++ b/packages/gluegun/test/fixtures/good-apps/basic/inapp/commands/hello.js
@@ -1,5 +1,5 @@
-// @command say
-// @description Says hello.
+// @cliCommand say
+// @cliDescription Says hello.
 
 module.exports = async function (context) {
   return 'hello'

--- a/packages/gluegun/test/fixtures/good-plugins/front-matter/commands/full.js
+++ b/packages/gluegun/test/fixtures/good-plugins/front-matter/commands/full.js
@@ -1,9 +1,8 @@
-// @command      full
-// @description  This is the full meal deal.
-// @functionName jimmy
+// @cliCommand      full
+// @cliDescription  This is the full meal deal.
 
 async function jimmy (context) {
   return 123
 }
 
-module.exports = { jimmy }
+module.exports = jimmy

--- a/packages/gluegun/test/fixtures/good-plugins/front-matter/extensions/hello.js
+++ b/packages/gluegun/test/fixtures/good-plugins/front-matter/extensions/hello.js
@@ -1,5 +1,4 @@
-// @extension   hello
-// @description Drops 'very' on the context.
+// @contextExtension   hello
 
 /**
  * An extension that returns very little.

--- a/packages/gluegun/test/fixtures/good-plugins/threepack/gluegun.toml
+++ b/packages/gluegun/test/fixtures/good-plugins/threepack/gluegun.toml
@@ -8,7 +8,6 @@ description = 'Returns a 1'
 [[commands]]
 name         = 'two'
 file         = 'two.js'
-functionName = 'omgTwo'
 description  = 'Returns a two'
 
 [[commands]]

--- a/packages/gluegun/test/fixtures/good-plugins/threepack/two.js
+++ b/packages/gluegun/test/fixtures/good-plugins/threepack/two.js
@@ -2,4 +2,4 @@ async function omgTwo (context) {
   return 'two'
 }
 
-module.exports = { omgTwo }
+module.exports = omgTwo

--- a/packages/gluegun/test/loaders/extension-loader.test.js
+++ b/packages/gluegun/test/loaders/extension-loader.test.js
@@ -52,6 +52,5 @@ test('has front matter', t => {
   t.is(extension.loadState, 'ok')
   t.is(extension.errorState, 'none')
   t.is(extension.name, 'hello')
-  t.is(extension.description, 'Drops \'very\' on the context.')
 })
 

--- a/packages/gluegun/test/loaders/toml-plugin-loader.test.js
+++ b/packages/gluegun/test/loaders/toml-plugin-loader.test.js
@@ -76,7 +76,6 @@ test('load commands with front matter', async t => {
   const full = plugin.commands[0]
   t.is(full.name, 'full')
   t.is(full.file, `${dir}/commands/full.js`)
-  t.is(full.functionName, 'jimmy')
   t.is(full.description, 'This is the full meal deal.')
   t.is(typeof full.run, 'function')
   t.is(await full.run(), 123)
@@ -90,7 +89,6 @@ test('loads extensions with front matter', async t => {
   t.is(plugin.extensions.length, 1)
   const ext = plugin.extensions[0]
   t.is(ext.name, 'hello')
-  t.is(ext.description, 'Drops \'very\' on the context.')
   t.is(typeof ext.setup, 'function')
   const live = ext.setup()
   t.truthy(live)

--- a/packages/sample-ignite-generators/commands/component.js
+++ b/packages/sample-ignite-generators/commands/component.js
@@ -1,6 +1,6 @@
 // ----------------------------------------------------------------------------
-// @command      generate component
-// @description  Generates a component, styles, and an optional test.
+// @cliCommand      generate component
+// @cliDescription  Generates a component, styles, and an optional test.
 // ----------------------------------------------------------------------------
 const { isNilOrEmpty } = require('ramdasauce')
 

--- a/packages/sample-ignite-generators/commands/container.js
+++ b/packages/sample-ignite-generators/commands/container.js
@@ -1,6 +1,6 @@
 // ----------------------------------------------------------------------------
-// @command      generate container
-// @description  Generates a redux smart component.
+// @cliCommand      generate container
+// @cliDescription  Generates a redux smart component.
 // ----------------------------------------------------------------------------
 const { isNilOrEmpty } = require('ramdasauce')
 

--- a/packages/sample-ignite-generators/commands/listview.js
+++ b/packages/sample-ignite-generators/commands/listview.js
@@ -1,5 +1,7 @@
-// @command      generate listview
-// @description  Generates a screen with a ListView + walkthrough.
+// ----------------------------------------------------------------------------
+// @cliCommand      generate listview
+// @cliDescription  Generates a screen with a ListView + walkthrough.
+// ----------------------------------------------------------------------------
 const { isNilOrEmpty } = require('ramdasauce')
 
 module.exports = async function (context) {

--- a/packages/sample-ignite-generators/commands/redux.js
+++ b/packages/sample-ignite-generators/commands/redux.js
@@ -1,6 +1,6 @@
 // ----------------------------------------------------------------------------
-// @command      generate redux
-// @description  Generates a action/creator/reducer set for Redux.
+// @cliCommand      generate redux
+// @cliDescription  Generates a action/creator/reducer set for Redux.
 // ----------------------------------------------------------------------------
 const { isNilOrEmpty } = require('ramdasauce')
 

--- a/packages/sample-ignite-generators/commands/saga.js
+++ b/packages/sample-ignite-generators/commands/saga.js
@@ -1,5 +1,7 @@
-// @command      generate saga
-// @description  Generates a saga with an optional test.
+// ----------------------------------------------------------------------------
+// @cliCommand      generate saga
+// @cliDescription  Generates a saga with an optional test.
+// ----------------------------------------------------------------------------
 const { isNilOrEmpty } = require('ramdasauce')
 
 module.exports = async function (context) {

--- a/packages/sample-ignite-generators/commands/screen.js
+++ b/packages/sample-ignite-generators/commands/screen.js
@@ -1,5 +1,7 @@
-// @command      generate screen
-// @description  Generates an opinionated container.
+// ----------------------------------------------------------------------------
+// @cliCommand      generate screen
+// @cliDescription  Generates an opinionated container.
+// ----------------------------------------------------------------------------
 const { isNilOrEmpty } = require('ramdasauce')
 
 module.exports = async function (context) {


### PR DESCRIPTION
Meta tags are now:

```js
// @cliCommand
// @cliDescription
// @contextExtension
```

I have remove `@description` for extensions since they do not appear in the CLI.

I have also removed @functionName` for commands in favour of convention.  They're the function that's exported from a `command/*.js`. 

Also, what I had before encouraged multiple commands per file.  And that won't work with `@functionName`.  So i burned it all.

