### PR TITLE
Adds a matching option to filter sub-directories when loading.

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -19,6 +19,7 @@ await build()
   .load('~/Desktop/movie/quote')
   .load('~/Desktop/movie/credits')
   .loadAll('~/Downloads/VariousMoviePlugins')
+  .loadAll('./node_modules', 'movies-*')
   .token('commandName', 'cliCommand')
   .token('commandDescription', 'cliDescription')
   .token('extensionName', 'contextExtension')
@@ -52,7 +53,7 @@ We'll be chaining the `build()` function from here.
 # Brand
 
 **Brand** is used through-out the glue for things like configuration file names and folder names for plugins.
- 
+
 ```js
   .brand('movie')
 ```
@@ -75,6 +76,12 @@ You can also load all immediate sub-directories located within it a directory.
 
 ```js
   .loadAll('~/Downloads/VariousMoviePlugins')
+```
+
+Load all supports a `fs-jetpack` [matching pattern](https://github.com/szwacz/fs-jetpack#findpath-searchoptions) so you can filter out a subset of directories instead of just all.
+
+```js
+  .loadAll('node_modules', 'movies-*')
 ```
 
 
@@ -122,7 +129,7 @@ $ movie quote random --funny
 $ movie credits actors Kingpin
 
 # run a command with arguments & options
-$ movie credits producers "Planes, Trains, & Automobiles" --sort age 
+$ movie credits producers "Planes, Trains, & Automobiles" --sort age
 ```
 
 So you see, it takes at least 2 extra arguments to run a command. That's because you can have multiple plugins and we need to qualify your commands with a namespace.
@@ -156,7 +163,7 @@ So, from our previous section, had we promoted the credits plugin to default, we
 $ movie actors Kingpin
 
 # run a command with arguments & options
-$ movie producers "Planes, Trains, & Automobiles" --sort age 
+$ movie producers "Planes, Trains, & Automobiles" --sort age
 ```
 
 Commands from the default plugin will now be evaluated first. If there is a match, they will be chosen over any other plugins.
@@ -183,7 +190,7 @@ await runtime.run({
 
 There's a few situations that make this useful.
 
-1. Maybe you like to use `meow` or `commander` to parse the command line. 
+1. Maybe you like to use `meow` or `commander` to parse the command line.
 2. Maybe your interface isn't a CLI.
 3. Maybe you want to run several command in a row.
 4. Maybe this is your program and you don't like strangers telling you how to code.

--- a/packages/gluegun/src/domain/builder.js
+++ b/packages/gluegun/src/domain/builder.js
@@ -49,7 +49,7 @@ class Builder {
       switch (entry.type) {
         case 'loadDefault': runtime.loadDefault(entry.value); break
         case 'load': runtime.load(entry.value); break
-        case 'loadAll': runtime.loadAll(entry.value); break
+        case 'loadAll': runtime.loadAll(entry.value, entry.matching); break
       }
     })
 
@@ -104,10 +104,11 @@ class Builder {
    * Add a plugin group to the list.
    *
    * @value {string} The directory with sub-directories.
+   * @matching {string} An optional jetpack glob matching to match.
    * @return {Builder} self.
    */
-  loadAll (value) {
-    this.loads.push({ type: 'loadAll', value })
+  loadAll (value, matching) {
+    this.loads.push({ type: 'loadAll', value, matching })
     return this
   }
 

--- a/packages/gluegun/src/domain/runtime.js
+++ b/packages/gluegun/src/domain/runtime.js
@@ -229,12 +229,13 @@ class Runtime {
    * Loads a bunch of plugins from the immediate sub-directories of a directory.
    *
    * @param {string} directory The directory to grab from.
+   * @param {string} matching  A jetpack matching pattern to filter the list.
    * @return {Plugin[]}        A bunch of plugins
    */
-  loadAll (directory) {
+  loadAll (directory, matching = '*') {
     if (isBlank(directory) || !isDirectory(directory)) return []
     return pipe(
-      subdirectories,
+      dir => subdirectories(dir, false, matching),
       map(this.load)
     )(directory)
   }

--- a/packages/gluegun/src/index.js
+++ b/packages/gluegun/src/index.js
@@ -19,6 +19,7 @@ const strings = require('./utils/string-utils')
 const print = require('./utils/print')
 const printCommands = require('./cli/print-commands')
 const printWtf = require('./cli/print-wtf')
+const { subdirectories } = require('./utils/filesystem-utils')
 
 // export our API
 module.exports = {
@@ -26,5 +27,6 @@ module.exports = {
   print,
   strings,
   printCommands,
-  printWtf
+  printWtf,
+  subdirectories
 }

--- a/packages/gluegun/src/utils/filesystem-utils.js
+++ b/packages/gluegun/src/utils/filesystem-utils.js
@@ -39,14 +39,15 @@ const isNotDirectory = complement(isDirectory)
  *
  * @param  {string} path       Path to a directory to check.
  * @param  {bool}   isRelative Return back the relative directory?
+ * @param  {string} matching   A jetpack matching filter
  * @return {string[]}          A list of directories
  */
-const subdirectories = (base, isRelative) => {
+const subdirectories = (base, isRelative, matching = '*') => {
   if (isBlank(base) || !isDirectory(base)) return []
   const dirs = jetpack
     .cwd(base)
     .find({
-      matching: '*',
+      matching,
       directories: true,
       recursive: false,
       files: false

--- a/packages/gluegun/test/exports.test.js
+++ b/packages/gluegun/test/exports.test.js
@@ -12,5 +12,6 @@ test('create', t => {
   t.is(typeof exported.printCommands, 'function')
   t.is(typeof exported.printWtf, 'function')
   t.is(typeof exported.print.info, 'function')
+  t.is(typeof exported.subdirectories, 'function')
   t.is(exported.strings.lowerCase('HI'), 'hi')
 })

--- a/packages/gluegun/test/utils/filesystem-utils.test.js
+++ b/packages/gluegun/test/utils/filesystem-utils.test.js
@@ -3,8 +3,10 @@ const {
   isFile,
   isNotFile,
   isDirectory,
-  isNotDirectory
+  isNotDirectory,
+  subdirectories
 } = require('../../src/utils/filesystem-utils')
+const { contains } = require('ramda')
 
 test('isFile', t => {
   t.true(isFile(__filename))
@@ -26,3 +28,20 @@ test('isNotDirectory', t => {
   t.true(isNotDirectory(__filename))
 })
 
+test('subdirectories', t => {
+  const dirs = subdirectories(`${__dirname}/..`)
+  t.is(7, dirs.length)
+  t.true(contains(`${__dirname}/../utils`, dirs))
+})
+
+test('relative subdirectories', t => {
+  const dirs = subdirectories(`${__dirname}/..`, true)
+  t.is(7, dirs.length)
+  t.true(contains(`utils`, dirs))
+})
+
+test('filtered subdirectories', t => {
+  const dirs = subdirectories(`${__dirname}/..`, true, 'ut*')
+  t.is(1, dirs.length)
+  t.true(contains(`utils`, dirs))
+})


### PR DESCRIPTION
Fixes #105 

One can now choose a subset of sub-directories to load, if one chooses.

```js
   .loadAll('node_modules', 'ignite-*')
```

I put this into the `subdirectories()` helper... and also exposed it via exports cuz it's kinda handy.