### PR TITLE
Plugins can now expose brand-based config.

### DIFF
--- a/packages/gluegun/src/loaders/toml-plugin-loader.js
+++ b/packages/gluegun/src/loaders/toml-plugin-loader.js
@@ -89,12 +89,13 @@ function loadFromDirectory (directory, options = {}) {
     const tomlFile = `${directory}/${brand}.toml`
 
     // read it
-    const config = toml.parse(jetpack.read(tomlFile))
+    const config = toml.parse(jetpack.read(tomlFile) || '') || {}
 
     // set the name if we have one (unless we were told what it was)
     if (isBlank(name)) {
       plugin.name = config.name || plugin.name
     }
+    plugin[brand] = config[brand]
     plugin.defaults = config.defaults || {}
     plugin.description = config.description
 


### PR DESCRIPTION
Plugins have config files.  And there's 3 different audiences for the types of information in them.

```toml
# this is for gluegun
description = 'Hello I am a plugin!'

# this is for the CLI
[ignite]
generators = ['screen', 'component']

# this is for end users
[defaults]
useSemiColons = false
```

This PR will make the branded one (the `ignite` in our example) will expose itself (lulz) as a property on the plugin.

So, you can do `plugin.ignite.generators` to fish out that info.

We need this in ignite to support the dynamic generators.


