### PR TITLE
Adds additional ways to launch commands with execa and spawn.

### DIFF
--- a/packages/gluegun/package.json
+++ b/packages/gluegun/package.json
@@ -31,6 +31,7 @@
     "colors": "^1.1.2",
     "ejs": "^2.5.5",
     "enquirer": "^0.4.1",
+    "execa": "^0.6.0",
     "fs-jetpack": "^0.10.3",
     "lodash": "^4.17.2",
     "minimist": "^1.2.0",

--- a/packages/gluegun/src/core-extensions/system-extension.js
+++ b/packages/gluegun/src/core-extensions/system-extension.js
@@ -1,5 +1,7 @@
-const { exec } = require('child_process')
+const { exec: nodeExec, spawn: nodeSpawn } = require('child_process')
 const clipboardy = require('clipboardy')
+const { split, head, tail } = require('ramda')
+const execa = require('execa')
 
 /**
  * Extensions to launch processes, open files, and talk to the clipboard.
@@ -9,16 +11,58 @@ const clipboardy = require('clipboardy')
 module.exports = function (plugin, command, context) {
   /**
    * Executes a commandline program asynchronously.
+   *
+   * @param {string} commandLine The command line to execute.
+   * @param {options} options Additional child_process options for node.
+   * @returns {Promise}
    */
-  async function run (commandLine, options = {}) {
+  async function run (commandLine, options) {
     return new Promise((resolve, reject) => {
-      exec(commandLine, options, (error, stdout, stderr) => {
+      nodeExec(commandLine, options, (error, stdout, stderr) => {
         if (error) {
           error.stderr = stderr
           reject(error)
         }
         resolve(stdout)
       })
+    })
+  }
+
+  /**
+   * Executes a commandline via execa.
+   *
+   * @param {string} commandLine The command line to execute.
+   * @param {options} options Additional child_process options for node.
+   * @returns {Promise}
+   */
+  async function exec (commandLine, options) {
+    return new Promise((resolve, reject) => {
+      const args = split(' ', commandLine)
+      execa(head(args), tail(args), options)
+        .then(result => resolve(result.stdout))
+        .catch(error => reject(error))
+    })
+  }
+
+  /**
+   * Uses Node JS's spawn to run a process.
+   *
+   * @param {any} commandLine The command line to execute.
+   * @param {options} options Additional child_process options for node.
+   * @returns {Promise} The response code.
+   */
+  async function spawn (commandLine, options) {
+    return new Promise((resolve, reject) => {
+      const args = split(' ', commandLine)
+      const spawned = nodeSpawn(head(args), tail(args), options)
+      spawned.on('close', function (code) {
+        if (code === 0) {
+          resolve(code)
+        } else {
+          reject(code)
+        }
+      })
+      spawned.on('error', () => reject())
     })
   }
 
@@ -40,5 +84,5 @@ module.exports = function (plugin, command, context) {
     clipboardy.writeSync(text)
   }
 
-  return { run, readFromClipboard, writeToClipboard }
+  return { exec, run, spawn, readFromClipboard, writeToClipboard }
 }


### PR DESCRIPTION
So running `react-native link` via `system.run` will hang.  So I brought in a few new ways to deal with it.  

I haven't committed to which one to use, so all 3 are now a thing.

I'm using `execa` for exec as it handles cross platform a little nicer.
