### PR TITLE
Fix plugin generation

### DIFF
--- a/packages/gluegun/src/core-extensions/template-extension.js
+++ b/packages/gluegun/src/core-extensions/template-extension.js
@@ -42,7 +42,7 @@ function attach (plugin, command, context) {
     // pick a base directory for templates
     const directory = opts.directory
       ? opts.directory
-      : `${plugin.directory}/templates/`
+      : `${plugin.directory}/templates`
 
     const pathToTemplate = `${directory}/${template}`
 


### PR DESCRIPTION
There's a double `/` in the path `node_modules/ignite-cli/src/cli/../templates//plugin/.gitignore`

     ruddell@MBP  /tmp/ignite  ignite plugin new ignite-jhipster
    ? Is this an app boilerplate plugin? Yes
    ? Will your plugin have an example component? No
    ? Will your plugin have a generator command? (e.g. ignite generate <mygenerator> <name>) Yes
    Creating new plugin: ignite-jhipster
    vvv -----[ DEBUG ]----- vvv
    Error: template not found /Users/ruddell/.nvm/versions/node/v7.7.1/lib/node_modules/ignite-cli/src/cli/../templates//plugin/.gitignore
        at Object.generate (/Users/ruddell/.nvm/versions/node/v7.7.1/lib/node_modules/ignite-cli/node_modules/gluegun/src/core-extensions/template-extension.js:51:13)
        at Object.copyBatch (/Users/ruddell/.nvm/versions/node/v7.7.1/lib/node_modules/ignite-cli/src/extensions/ignite/copyBatch.js:41:24)
        at process._tickCallback (internal/process/next_tick.js:109:7)
    ^^^ -----[ DEBUG ]----- ^^^