### PR TITLE
Adds coveralls & removes harmony flags.

### DIFF
--- a/packages/gluegun/package.json
+++ b/packages/gluegun/package.json
@@ -4,10 +4,11 @@
   "description": "Build yourself a pluggable CLI.",
   "main": "src/index.js",
   "scripts": {
-    "test": "node --harmony_async_await node_modules/.bin/ava",
-    "watch": "node --harmony node_modules/.bin/ava --watch",
+    "test": "ava",
+    "watch": "ava --watch",
     "coverage": "nyc ava",
-    "start": "node --harmony_async_await src/index.js",
+    "coveralls": "nyc ava && nyc report --reporter=text-lcov | coveralls",
+    "start": "node src/index.js",
     "lint": "standard"
   },
   "author": {
@@ -55,6 +56,7 @@
   "devDependencies": {
     "ava": "^0.18.1",
     "babel-eslint": "^7.1.1",
+    "coveralls": "^2.12.0",
     "nyc": "^10.1.2",
     "standard": "^8.6.0"
   },


### PR DESCRIPTION
The harmony flags are no longer needed since we're using 7.6.

I added a coveralls script that we can run from CI too.