### PR TITLE
Upgrades deps and shave 8 MB off size.

### DIFF
--- a/packages/gluegun/package.json
+++ b/packages/gluegun/package.json
@@ -24,17 +24,17 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "apisauce": "^0.10.0",
+    "apisauce": "^0.11.0",
     "app-module-path": "^2.2.0",
     "ascii-table": "^0.0.9",
     "autobind-decorator": "^1.3.4",
-    "clipboardy": "^0.1.2",
+    "clipboardy": "^1.0.1",
     "colors": "^1.1.2",
     "cross-spawn": "^5.1.0",
     "ejs": "^2.5.5",
     "enquirer": "^0.4.1",
     "execa": "^0.6.0",
-    "fs-jetpack": "^0.11.0",
+    "fs-jetpack": "^0.13.1",
     "lodash": "^4.17.4",
     "minimist": "^1.2.0",
     "ora": "^1.1.0",
@@ -58,7 +58,7 @@
     "babel-eslint": "^7.1.1",
     "coveralls": "^2.12.0",
     "nyc": "^10.1.2",
-    "standard": "^8.6.0"
+    "standard": "^9.0.1"
   },
   "ava": {},
   "standard": {

--- a/packages/gluegun/src/domain/runtime.js
+++ b/packages/gluegun/src/domain/runtime.js
@@ -122,7 +122,7 @@ async function run (options) {
   context.config = clone(this.config)
   context.config[context.plugin.name] = merge(
     context.plugin.defaults,
-    this.defaults && this.defaults[context.plugin.name] || {}
+    (this.defaults && this.defaults[context.plugin.name]) || {}
   )
 
   // jet if we have no command

--- a/packages/gluegun/test/extensions/http-extension.test.js
+++ b/packages/gluegun/test/extensions/http-extension.test.js
@@ -1,8 +1,47 @@
 const test = require('ava')
 const createExtension = require('../../src/core-extensions/http-extension')
+const http = require('http')
+
+/**
+ * Sends a HTTP response.
+ *
+ * @param {*} res - The http response object.
+ * @param {number} statusCode - The http response status code.
+ * @param {string} body - The reponse data.
+ */
+const sendResponse = (res, statusCode, body) => {
+  res.writeHead(statusCode)
+  res.write(body)
+  res.end()
+}
+
+/**
+ * Sends a 200 OK with some data.
+ *
+ * @param {*} res - The http response object.
+ * @param {string} body - The http response data.
+ */
+const send200 = (res, body) => {
+  sendResponse(res, 200, body || '<h1>OK</h1>')
+}
 
 test('has the proper interface', t => {
   const ext = createExtension()
   t.truthy(ext)
   t.is(typeof ext.create, 'function')
 })
+
+test('connects to a server', async t => {
+  const ext = createExtension()
+  const server = http.createServer((req, res) => {
+    send200(res, 'hi')
+  })
+  server.listen()
+  const port = server.address().port
+  const api = ext.create({
+    baseURL: `http://127.0.0.1:${port}`
+  })
+  const response = await api.get('/')
+  t.is(response.data, 'hi')
+})
+

--- a/packages/gluegun/test/fixtures/bad-modules/number.js
+++ b/packages/gluegun/test/fixtures/bad-modules/number.js
@@ -1,1 +1,1 @@
-3
+module.exports = 3 // eslint-line-disable

--- a/packages/gluegun/test/fixtures/good-plugins/auto-detect/commands/detectCommand.js
+++ b/packages/gluegun/test/fixtures/good-plugins/auto-detect/commands/detectCommand.js
@@ -1,2 +1,1 @@
 module.exports = async function (context) { }
-

--- a/packages/gluegun/test/loaders/module-loader.test.js
+++ b/packages/gluegun/test/loaders/module-loader.test.js
@@ -30,7 +30,7 @@ test('handles blank files', t => {
 
 test('handles files with just a number', t => {
   const m = loadModule(`${__dirname}/../fixtures/bad-modules/number.js`)
-  t.is(typeof m, 'object')
+  t.is(typeof m, 'number')
   t.deepEqual(keys(m), [])
 })
 


### PR DESCRIPTION
We fixed some lame stuff in apisauce and now our production footprint on gluegun looks like this:

From
![image](https://cloud.githubusercontent.com/assets/68273/24049684/2349d1c0-0b03-11e7-8771-612aac20a688.png)

To
![image](https://cloud.githubusercontent.com/assets/68273/24049623/0870aedc-0b03-11e7-86dc-4e4930806d76.png)

I also added a real test for `context.http.create` which includes hitting a local http server.
