### PR TITLE
Exports several extensions without need for context.

### DIFF
--- a/packages/gluegun/src/core-extensions/template-extension.js
+++ b/packages/gluegun/src/core-extensions/template-extension.js
@@ -26,8 +26,8 @@ function attach (plugin, command, context) {
 
     // add some goodies to the environment so templates can read them
     const data = {
-      config: context.config,
-      parameters: context.parameters,
+      config: context && context.config,
+      parameters: context && context.parameters,
       props: props
     }
 
@@ -42,7 +42,7 @@ function attach (plugin, command, context) {
     // pick a base directory for templates
     const directory = opts.directory
       ? opts.directory
-      : `${plugin.directory}/templates`
+      : `${plugin && plugin.directory}/templates`
 
     const pathToTemplate = `${directory}/${template}`
 

--- a/packages/gluegun/src/index.js
+++ b/packages/gluegun/src/index.js
@@ -22,6 +22,13 @@ const printCommands = require('./cli/print-commands')
 const printWtf = require('./cli/print-wtf')
 const { subdirectories } = require('./utils/filesystem-utils')
 
+// bring in a few extensions to make available for stand-alone purposes
+const filesystem = require('./core-extensions/filesystem-extension')()
+const system = require('./core-extensions/system-extension')()
+const prompt = require('./core-extensions/prompt-extension')()
+const http = require('./core-extensions/http-extension')()
+const template = require('./core-extensions/template-extension')()
+
 // export our API
 module.exports = {
   build,
@@ -29,5 +36,10 @@ module.exports = {
   strings,
   printCommands,
   printWtf,
-  subdirectories
+  subdirectories,
+  filesystem,
+  system,
+  prompt,
+  http,
+  template
 }

--- a/packages/gluegun/test/exports.test.js
+++ b/packages/gluegun/test/exports.test.js
@@ -1,17 +1,55 @@
 const test = require('ava')
-const idx = require('../src/index')
+const exported = require('../src/index')
 
 test('create', t => {
-  const exported = idx
   t.truthy(exported)
   t.is(typeof exported.build, 'function')
   const { build } = exported
   const runtime = build().brand('test').createRuntime()
   t.is(runtime.brand, 'test')
+  t.is(typeof exported.subdirectories, 'function')
+})
 
+test('print', t => {
   t.is(typeof exported.printCommands, 'function')
   t.is(typeof exported.printWtf, 'function')
   t.is(typeof exported.print.info, 'function')
-  t.is(typeof exported.subdirectories, 'function')
+})
+
+test('strings', t => {
   t.is(exported.strings.lowerCase('HI'), 'hi')
+})
+
+test('filesystem', t => {
+  t.truthy(exported.filesystem)
+  t.truthy(exported.filesystem.eol)
+  t.truthy(exported.filesystem.separator)
+  t.is(exported.filesystem.cwd(), process.cwd())
+})
+
+test('system', t => {
+  t.truthy(exported.system)
+  t.truthy(exported.system.which('node'))
+})
+
+test('prompt', t => {
+  t.truthy(exported.prompt)
+  t.truthy(typeof exported.prompt.confirm, 'function')
+})
+
+test('http', t => {
+  t.truthy(exported.http)
+  t.truthy(typeof exported.http.create, 'function')
+  const api = exported.http.create({ baseURL: 'https://api.github.com/v3' })
+  t.is(typeof api.get, 'function')
+  t.is(typeof api.post, 'function')
+})
+
+test('generate', async t => {
+  t.truthy(exported.template)
+  const actual = await exported.template.generate({
+    template: './test/fixtures/good-plugins/generate/templates/simple.ejs',
+    directory: process.cwd()
+  })
+  t.is(actual, 'simple file\n')
 })


### PR DESCRIPTION
Allows access to some of the extensions without having to go through the gluegun lifecycle.

```js
import { system } from 'gluegun'

console.log(system.which('node'))
```

Fixes #194 