### PR TITLE
Reverts the loader refactoring change

### DIFF
--- a/packages/gluegun/src/loaders/command-loader.js
+++ b/packages/gluegun/src/loaders/command-loader.js
@@ -29,8 +29,8 @@ const findTokens = require('./find-tokens')
 /**
  * Loads the command from the given file.
  *
- * @param  {string} file The full path to the file to load.
- * @return {Command}     The command in any condition
+ * @param  {string} file      The full path to the file to load.
+ * @return {Command}          The command in any condition
  */
 function loadFromFile (file, options = {}) {
   const command = new Command()

--- a/packages/gluegun/src/loaders/extension-loader.js
+++ b/packages/gluegun/src/loaders/extension-loader.js
@@ -1,0 +1,70 @@
+const { isNotFile } = require('../utils/filesystem-utils')
+const { isBlank } = require('../utils/string-utils')
+const loadModule = require('./module-loader')
+const findTokens = require('./find-tokens')
+const jetpack = require('fs-jetpack')
+const { head, split } = require('ramda')
+const Extension = require('../domain/extension')
+
+/**
+ * Loads the extension from a file.
+ *
+ * @param {string} file         The full path to the file to load.
+ */
+function loadFromFile (file, options = {}) {
+  const extension = new Extension()
+
+  const extensionNameToken = options.extensionNameToken ||
+    'gluegunExtensionName'
+
+  // sanity check the input
+  if (isBlank(file)) {
+    extension.loadState = 'error'
+    extension.errorState = 'input'
+    return extension
+  }
+
+  extension.file = file
+
+  // not a file?
+  if (isNotFile(file)) {
+    extension.loadState = 'error'
+    extension.errorState = 'missing'
+    return extension
+  }
+
+  // default is the name of the file without the extension
+  extension.name = head(split('.', jetpack.inspect(file).name))
+
+  // let's load
+  try {
+    // try reading in tokens embedded in the file
+    const tokens = findTokens(jetpack.read(file) || '', [extensionNameToken])
+
+    // let's override if we've found these tokens
+    extension.name = tokens[extensionNameToken] || extension.name
+
+    // require in the module -- best chance to bomb is here
+    const extensionModule = loadModule(file)
+
+    // should we try the default export?
+    const valid = extensionModule && typeof extensionModule === 'function'
+
+    if (valid) {
+      extension.loadState = 'ok'
+      extension.errorState = 'none'
+      extension.setup = extensionModule
+    } else {
+      extension.loadState = 'error'
+      extension.errorState = 'badfunction'
+    }
+  } catch (e) {
+    extension.exception = e
+    extension.loadState = 'error'
+    extension.errorState = 'badfile'
+  }
+
+  return extension
+}
+
+module.exports = loadFromFile

--- a/packages/gluegun/src/loaders/toml-plugin-loader.js
+++ b/packages/gluegun/src/loaders/toml-plugin-loader.js
@@ -1,7 +1,7 @@
 const jetpack = require('fs-jetpack')
 const Plugin = require('../domain/plugin')
-const loadCommandFromFile = require('./loader')
-//  const loadExtensionFromFile = require('./extension-loader')
+const loadCommandFromFile = require('./command-loader')
+const loadExtensionFromFile = require('./extension-loader')
 const { isNotDirectory } = require('../utils/filesystem-utils')
 const { isBlank } = require('../utils/string-utils')
 const { assoc, map } = require('ramda')
@@ -80,7 +80,7 @@ function loadFromDirectory (directory, options = {}) {
   if (jetpackPlugin.exists('extensions') === 'dir') {
     plugin.extensions = map(
       file =>
-        loadCommandFromFile(`${directory}/extensions/${file}`, {
+        loadExtensionFromFile(`${directory}/extensions/${file}`, {
           extensionNameToken
         }),
       jetpackPlugin

--- a/packages/gluegun/test/loaders/command-loader.test.js
+++ b/packages/gluegun/test/loaders/command-loader.test.js
@@ -1,5 +1,5 @@
 const test = require('ava')
-const loadCommandFromFile = require('../../src/loaders/loader')
+const loadCommandFromFile = require('../../src/loaders/command-loader')
 
 test('loading from a missing file', t => {
   const command = loadCommandFromFile('foo.js')

--- a/packages/gluegun/test/loaders/extension-loader.test.js
+++ b/packages/gluegun/test/loaders/extension-loader.test.js
@@ -1,9 +1,9 @@
 const test = require('ava')
-const load = require('../../src/loaders/loader')
+const load = require('../../src/loaders/extension-loader')
 
 test('loading from a missing file', t => {
-  const extension = load('foo.js')
-  t.falsy(extension.run)
+  const extension = load('foo.js', 'extension')
+  t.falsy(extension.setup)
   t.falsy(extension.exception)
   t.is(extension.loadState, 'error')
   t.is(extension.errorState, 'missing')
@@ -11,7 +11,7 @@ test('loading from a missing file', t => {
 
 test('deals with wierd input', t => {
   const extension = load()
-  t.falsy(extension.run)
+  t.falsy(extension.setup)
   t.falsy(extension.exception)
   t.is(extension.loadState, 'error')
   t.is(extension.errorState, 'input')
@@ -19,8 +19,8 @@ test('deals with wierd input', t => {
 
 test('open a wierd js file', t => {
   const file = `${__dirname}/../fixtures/bad-modules/text.js`
-  const extension = load(file)
-  t.falsy(extension.run)
+  const extension = load(file, 'extension')
+  t.falsy(extension.setup)
   t.truthy(extension.exception)
   t.is(extension.loadState, 'error')
   t.is(extension.errorState, 'badfile')
@@ -28,8 +28,8 @@ test('open a wierd js file', t => {
 
 test('default but none exported', t => {
   const file = `${__dirname}/../fixtures/good-modules/module-exports-object.js`
-  const extension = load(file)
-  t.falsy(extension.run)
+  const extension = load(file, 'extension')
+  t.falsy(extension.setup)
   t.falsy(extension.exception)
   t.is(extension.loadState, 'error')
   t.is(extension.errorState, 'badfunction')
@@ -37,18 +37,18 @@ test('default but none exported', t => {
 
 test('fat arrows', t => {
   const file = `${__dirname}/../fixtures/good-modules/module-exports-fat-arrow-fn.js`
-  const extension = load(file)
+  const extension = load(file, 'extension')
   t.falsy(extension.exception)
-  t.is(typeof extension.run, 'function')
+  t.is(typeof extension.setup, 'function')
   t.is(extension.loadState, 'ok')
   t.is(extension.errorState, 'none')
 })
 
 test('has front matter', t => {
   const file = `${__dirname}/../fixtures/good-plugins/front-matter/extensions/hello.js`
-  const extension = load(file)
+  const extension = load(file, 'extension')
   t.falsy(extension.exception)
-  t.is(typeof extension.run, 'function')
+  t.is(typeof extension.setup, 'function')
   t.is(extension.loadState, 'ok')
   t.is(extension.errorState, 'none')
   t.is(extension.name, 'hello')

--- a/packages/gluegun/test/loaders/toml-plugin-loader.test.js
+++ b/packages/gluegun/test/loaders/toml-plugin-loader.test.js
@@ -91,8 +91,8 @@ test('loads extensions with front matter', async t => {
   t.is(plugin.extensions.length, 1)
   const ext = plugin.extensions[0]
   t.is(ext.name, 'hello')
-  t.is(typeof ext.run, 'function')
-  const live = ext.run()
+  t.is(typeof ext.setup, 'function')
+  const live = ext.setup()
   t.truthy(live)
   t.is(live.very, 'little')
 })


### PR DESCRIPTION
Ran into some issues with #184 so I'm rolling back for now.

The extensions interface had change from `.setup` to `.run` which slip passed me.