### PR TITLE
Pass through the name of a plugin when loading it

### DIFF
--- a/packages/gluegun/src/domain/runtime.js
+++ b/packages/gluegun/src/domain/runtime.js
@@ -241,6 +241,7 @@ class Runtime {
       commandDescriptionToken,
       brand,
       hidden: options['hidden'],
+      name: options['name'],
       commandFilePattern: options['commandFilePattern'],
       extensionFilePattern: options['extensionFilePattern']
     })


### PR DESCRIPTION
This prevents `plugin.name` (on the default plugin) from being `src` and lets you do this:

```javascript
  const runtime =
    build()
    .brand('gluegun')
    .loadDefault(`${__dirname}`, { name: 'gluegun' })
    // ...
```