### PR TITLE
Adds normalizedParams as context.params

### DIFF
--- a/packages/gluegun/src/cli/normalize-params.js
+++ b/packages/gluegun/src/cli/normalize-params.js
@@ -7,7 +7,9 @@ const minimist = require('minimist')
  */
 function normalizeParams (plugin, command, argv = []) {
   // chop it up minimist!
-  const { _: array, ...options } = minimist(argv.slice(2))
+  const options = minimist(argv.slice(2))
+  const array = options._
+  delete options._
 
   // the plugin name or command is sometimes the first/second word -- delete them
   if (array[0] == plugin) { array.shift() }

--- a/packages/gluegun/src/cli/normalize-params.js
+++ b/packages/gluegun/src/cli/normalize-params.js
@@ -1,0 +1,28 @@
+const minimist = require('minimist')
+
+/**
+ * Parses the command-line arguments into a normalized object.
+ *
+ * @return {{}} An object with our awesome keys.
+ */
+function normalizeParams (plugin, command, argv = []) {
+  // chop it up minimist!
+  const { _: array, ...options } = minimist(argv.slice(2))
+
+  // the plugin name or command is sometimes the first/second word -- delete them
+  if (array[0] == plugin) { array.shift() }
+  if (array[0] == command) { array.shift() }
+
+  const first = array[0]
+  const second = array[1]
+  const third = array[2]
+
+  // the rawCommand is the rest of the words
+  const raw = array.join(' ')
+
+  // :shipit:
+  return { argv, first, second, third, raw, array, options }
+}
+
+module.exports = normalizeParams
+

--- a/packages/gluegun/src/domain/runtime.js
+++ b/packages/gluegun/src/domain/runtime.js
@@ -149,11 +149,10 @@ async function run (options) {
     process.argv
   )
 
-  context.params = {
-    ...normalizedParams,
+  context.params = Object.assign(normalizedParams, {
     plugin: context.plugin.name,
     command: context.command.name,
-  }
+  })
 
   // kick it off
   if (context.command.run) {

--- a/packages/gluegun/src/domain/runtime.js
+++ b/packages/gluegun/src/domain/runtime.js
@@ -1,4 +1,5 @@
 const parseCommandLine = require('../cli/parse-command-line')
+const normalizeParams = require('../cli/normalize-params')
 const autobind = require('autobind-decorator')
 const {
   clone,
@@ -140,6 +141,19 @@ async function run (options) {
   context.parameters.second = subArgs[1]
   context.parameters.third = subArgs[2]
   context.parameters.string = join(COMMAND_DELIMITER, subArgs)
+
+  // normalized params (experimental)
+  const normalizedParams = normalizeParams(
+    context.plugin.name,
+    context.command.name,
+    process.argv
+  )
+
+  context.params = {
+    ...normalizedParams,
+    plugin: context.plugin.name,
+    command: context.command.name,
+  }
 
   // kick it off
   if (context.command.run) {


### PR DESCRIPTION
Experimental, better params support.

Ref #6 and #123.

Note that this recognizes the plugin name & command name and strips those out (adding them back in as `params.plugin` and `params.command`). It works whether you do `mycli plugin command foo` or `mycli command foo`.

<img width="749" alt="screen shot 2017-09-26 at 12 08 39 am" src="https://user-images.githubusercontent.com/1479215/30847156-54605822-a24f-11e7-8f81-55bb040f7982.png">

Discussion welcome, or yolo merging, either way.
