### PR TITLE
Adds ability for extensions to optionally return a new or modified context

### DIFF
--- a/packages/gluegun/src/core-extensions/filesystem-extension.js
+++ b/packages/gluegun/src/core-extensions/filesystem-extension.js
@@ -15,6 +15,7 @@ function attach (context) {
   extension.subdirectories = subdirectories
 
   context.filesystem = extension
+  return context
 }
 
 module.exports = attach

--- a/packages/gluegun/src/core-extensions/http-extension.js
+++ b/packages/gluegun/src/core-extensions/http-extension.js
@@ -7,6 +7,7 @@ const { create } = require('apisauce')
  */
 function attach (context) {
   context.http = { create }
+  return context
 }
 
 module.exports = attach

--- a/packages/gluegun/src/core-extensions/patching-extension.js
+++ b/packages/gluegun/src/core-extensions/patching-extension.js
@@ -122,6 +122,7 @@ function attach (context) {
   }
 
   context.patching = { update, append, prepend, replace, patch }
+  return context
 }
 
 module.exports = attach

--- a/packages/gluegun/src/core-extensions/print-extension.js
+++ b/packages/gluegun/src/core-extensions/print-extension.js
@@ -67,6 +67,7 @@ function attach (context) {
     newline: print.newline,
     color: colors
   }
+  return context
 }
 
 module.exports = attach

--- a/packages/gluegun/src/core-extensions/prompt-extension.js
+++ b/packages/gluegun/src/core-extensions/prompt-extension.js
@@ -36,6 +36,7 @@ function attach (context) {
   enquirer.confirm = confirm
 
   context.prompt = enquirer
+  return context
 }
 
 module.exports = attach

--- a/packages/gluegun/src/core-extensions/semver-extension.js
+++ b/packages/gluegun/src/core-extensions/semver-extension.js
@@ -10,6 +10,7 @@ function attach (context) {
   // Add bells and whistles here
 
   context.semver = extension
+  return context
 }
 
 module.exports = attach

--- a/packages/gluegun/src/core-extensions/strings-extension.js
+++ b/packages/gluegun/src/core-extensions/strings-extension.js
@@ -7,6 +7,7 @@ const stringUtils = require('../utils/string-utils')
  */
 function attach (context) {
   context.strings = stringUtils
+  return context
 }
 
 module.exports = attach

--- a/packages/gluegun/src/core-extensions/system-extension.js
+++ b/packages/gluegun/src/core-extensions/system-extension.js
@@ -95,4 +95,5 @@ module.exports = function (context) {
   }
 
   context.system = { exec, run, spawn, which }
+  return context
 }

--- a/packages/gluegun/src/core-extensions/template-extension.js
+++ b/packages/gluegun/src/core-extensions/template-extension.js
@@ -73,6 +73,7 @@ function attach (context) {
   }
 
   context.template = { generate }
+  return context
 }
 
 module.exports = attach

--- a/packages/gluegun/src/domain/runtime-extensions.test.js
+++ b/packages/gluegun/src/domain/runtime-extensions.test.js
@@ -1,5 +1,6 @@
 const test = require('ava')
 const Runtime = require('./runtime')
+const RunContext = require('./run-context')
 const { pipe, pluck, join } = require('ramda')
 
 test('loads the core extensions in the right order', t => {
@@ -7,4 +8,44 @@ test('loads the core extensions in the right order', t => {
   const list = pipe(pluck('name'), join(', '))(r.extensions)
 
   t.is(list, 'strings, print, template, filesystem, semver, system, http, prompt, patching')
+})
+
+test('extensions can return new contexts or mutate the existing one', t => {
+  t.plan(2)
+
+  const r = new Runtime()
+
+  r.addExtension('firstExtension', (context) => {
+    // mutate the old context
+    context.foo = 'NOPE'
+
+    // return a brand-new context
+    const newContext = new RunContext()
+    newContext.foo = 'AAAA'
+    return newContext
+  })
+
+  r.addExtension('secondExtension', (context) => {
+    // make sure the new context came through
+    t.is('AAAA', context.foo)
+    // mutate it
+    context.foo = 'BBBB'
+    // doesn't return, so use the one we just mutated
+  })
+
+  r.brand = 'test'
+  r.defaultPlugin = {
+    name: 'test',
+    commands: [{
+      name: 'test',
+      commandPath: ['test'],
+      run: (context) => {
+        // check to make sure the mutation came through
+        t.is('BBBB', context.foo)
+      }
+    }]
+  }
+  r.plugins = [ r.defaultPlugin ]
+
+  r.run('test test')
 })


### PR DESCRIPTION
@GantMan and I were discussing how this feels more natural to us as plugin / cli authors -- that we take in a context and return a context.

However, I think allowing mutating the original context and not returning is also a viable strategy, so I'm allowing that as well.

Mutating a context and returning it doesn't really _do_ anything, but it does feel better and seem more logical. context in, mutate, context out.

```js
 /**
  * My extension
  *
  * @param  {RunContext} context The running context.
   */
  module.exports = (context) => {
    context.mything = () => { return 'garbage' }
    return context
  }
```
