### PR TITLE
Updates printCommands to be included in context.print

### DIFF
--- a/docs/context-print.md
+++ b/docs/context-print.md
@@ -108,3 +108,19 @@ The text can also be set with the normal printing colors.
 ```js
 spinner.text = context.print.colors.green('i like trees')
 ```
+
+## printCommands
+
+Prints out a table of available commands in a given context.
+
+```js
+const { printCommands } = context.print
+printCommands(context)
+```
+
+You can pass in a "command path" to refine what commands you'd like to see:
+
+```js
+const { printCommands } = context.print
+printCommands(context, ['generate', 'model'])
+```

--- a/packages/gluegun-cli/src/commands/generate/help.js
+++ b/packages/gluegun-cli/src/commands/generate/help.js
@@ -1,4 +1,11 @@
 module.exports = {
   name: 'help',
-  run: () => { console.log('generate help'); return 'generate helped' }
+  run: (context) => {
+    const { info, printCommands } = context.print
+
+    info('GlueGun CLI')
+    printCommands(context, ['generate'])
+
+    return 'generate helped'
+  }
 }

--- a/packages/gluegun-cli/src/commands/help.js
+++ b/packages/gluegun-cli/src/commands/help.js
@@ -3,5 +3,12 @@ module.exports = {
   alias: [ 'h' ],
   description: 'Displays this help',
   hidden: false,
-  run: (context) => { console.log('help'); return 'helped' }
+  run: (context) => {
+    const { info, printCommands } = context.print
+
+    info('GlueGun CLI')
+    printCommands(context)
+
+    return 'helped'
+  }
 }

--- a/packages/gluegun/src/core-extensions/print-extension.js
+++ b/packages/gluegun/src/core-extensions/print-extension.js
@@ -1,4 +1,5 @@
 const print = require('../utils/print')
+const printCommands = require('../cli/print-commands')
 const ora = require('ora')
 
 /**
@@ -62,6 +63,7 @@ function attach (context) {
     checkmark,
     xmark,
     spin,
+    printCommands,
 
     table: print.table,
     newline: print.newline,

--- a/packages/gluegun/src/domain/command.js
+++ b/packages/gluegun/src/domain/command.js
@@ -9,6 +9,16 @@ class Command {
     this.run = null
     this.hidden = false
     this.commandPath = null
+    this.alias = null
+  }
+
+  get aliases () {
+    if (this.alias === null) { return [] }
+    return Array.isArray(this.alias) ? this.alias : [ this.alias ]
+  }
+
+  hasAlias () {
+    return this.alias !== null && this.alias.length > 0
   }
 }
 


### PR DESCRIPTION
Also works with new command structure and allows refining for nested commands.

![image](https://user-images.githubusercontent.com/1479215/31049758-e6e7401e-a5ee-11e7-8906-16cc5b54efc0.png)

```js
const { printCommands } = context.print
printCommands(context, ['generate', 'model'])
```

My confidence level that this is the right way to approach this is medium, not high. I think it's _fine_ but there may be a better way. Happy to entertain ideas.

