### PR TITLE
Adds a stopwatch.

### DIFF
--- a/docs/context-system.md
+++ b/docs/context-system.md
@@ -27,7 +27,7 @@ const nodeVersion = context.system.run('node -v', { trim: true })
 
 ### context.system.which
 
-Retursn the full path to a command on your system if located on your path.
+Returns the full path to a command on your system if located on your path.
 
 ```js
 const whereIsIt = context.system.which('npm')
@@ -36,3 +36,17 @@ const whereIsIt = context.system.which('npm')
 ### context.system.open
 :(
 
+### context.system.startTimer
+
+Starts a timer for... well... timing stuff.  `startTimer()` returns a function.  When this is called, the number of milliseconds will be returned.
+
+```js
+const timer = context.system.startTimer()
+
+// time passes...
+console.log(`that just took ${timer()} ms.`)
+```
+
+Caveat: Due to the event loop scheduler in Node.JS, they don't guarantee millisecond accuracy when invoking async functions.  For that reason, expect a up to a 4ms overage.
+
+Note that this lag doesn't apply to synchronous code.

--- a/packages/gluegun/gluegun.d.ts
+++ b/packages/gluegun/gluegun.d.ts
@@ -590,6 +590,11 @@ export interface GluegunPrintUtils {
   colors: any
 }
 
+/**
+ * Returns the number of milliseconds from when the timer started.
+ */
+export type GluegunTimer = () => number
+
 export interface GluegunSystem {
   /**
    * Executes a command via execa.
@@ -607,6 +612,12 @@ export interface GluegunSystem {
    * Uses node-which to find out where the command lines.
    */
   which(command: string): string | void
+  /**
+   * Returns a timer function that starts from this moment. Calling 
+   * this function will return the number of milliseconds from when
+   * it was started.
+   */
+  startTimer(): GluegunTimer
 }
 
 export interface GluegunSemver {

--- a/packages/gluegun/src/core-extensions/system-extension.js
+++ b/packages/gluegun/src/core-extensions/system-extension.js
@@ -94,5 +94,15 @@ module.exports = function (context) {
     return nodeWhich.sync(command)
   }
 
-  context.system = { exec, run, spawn, which }
+  /**
+   * Starts a timer used for measuring durations.
+   * 
+   * @return {function} A function that when called will return the elapsed duration in milliseconds.
+   */
+  function startTimer() {
+    const started = process.uptime()
+    return () => Math.floor((process.uptime() - started) * 1000) // uptime gives us seconds
+  }
+
+  context.system = { exec, run, spawn, which, startTimer }
 }

--- a/packages/gluegun/src/core-extensions/system-extension.test.js
+++ b/packages/gluegun/src/core-extensions/system-extension.test.js
@@ -1,6 +1,8 @@
 const test = require('ava')
 const create = require('./system-extension')
 
+const delay = ms => new Promise((resolve) => setTimeout(resolve, ms))
+
 const context = {}
 create(context)
 const system = context.system
@@ -46,4 +48,16 @@ test('spawn deals exit codes', async t => {
   const crap = await system.spawn('npm')
   t.falsy(crap.error)
   t.is(crap.status, 1)
+})
+
+test.serial('start timer returns the number of milliseconds', async t => {
+  const WAIT = 10
+  const NODE_JS_EVENT_LOOP_LAG = 4 // nodejs doesn't guarantee accurate millisecond timing in their event loop
+
+  const elapsed = system.startTimer() // start a timer
+  await delay(WAIT) // simulate a delay
+  const duration = elapsed() // how long was that?
+
+  // are we within the parameters of "acceptable"?
+  t.true(duration >= WAIT && duration <= WAIT + NODE_JS_EVENT_LOOP_LAG)
 })


### PR DESCRIPTION
```js
const finished = context.system.startTimer()

// 1 second later

const elapsed = finished()  // 1000
```

Closes #197