### PR TITLE
Releases v2.0.0-alpha.1 on `next` dist-tag.

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,57 @@
+# Releasing Gluegun
+
+#### Once per machine
+
+1. you have a `npm` token. Type `npm whoami`. It should say your name.
+1. you have publishing rights to `gluegun` on npm.
+1. you have `yarn@>=1.1.0` installed. Help us `solidarity`! We need you!
+
+#### Preflight sanity checks
+
+1. make sure you're in the project root directory
+1. switch to the `master` branch: `git checkout master`
+1. you have all latest updates: `git pull`
+1. you have no changes to push and no staged changes.
+1. nuke your dependencies: `yarn clean`
+1. install fresh dependencies: `yarn bootstrap`
+1. tests pass: `yarn test`
+
+#### Pushing an alpha
+
+This will be automated a little nicer later. I'll also update these instructions next time I release.  This time I used `yarn`.  Next time I'll try `npm`.  `yarn` is still messed up when publishing. :sad:
+
+1. ensure you have something to release: `yarn lerna outdated`, you should see both `gluegun` and `gluegun-cli`.
+1. make a new branch: `git branch alpha2`
+1. bump versions: `yarn lerna publish --skip-npm --npm-tag next`
+1. at the prompt, select `custom` and enter `2.0.0-alpha.2` (or whatever number we're on).
+1. release the lib manually (lulz): `cd packages/gluegun && npm publish --tag next && cd ../..`
+1. release cli too: `cd packages/gluegun-cli && npm publish --tag next && cd ../..`
+1. push code up to github: `git push -u origin HEAD`
+1. push new tag up to github: `git push --tags`
+
+Those last 5 steps are lame and we can streamline.  I'll do this with `2.0.0-alpha.2` and cut down the steps.
+
+We can & should use `yarn lerna publish --npm-tag next`, but `yarn` is causing grief.
+
+#### Verify
+
+`yarn info gluegun dist-tags` shows you what everyone sees.
+
+```sh
+yarn info gluegun dist-tags
+```
+shows:
+```
+yarn info v1.1.0
+{ latest: '1.0.0',
+ next: '2.0.0-alpha.1' }
+✨  Done in 0.71s.
+```
+
+#### To Use 2.0 Alphas
+
+In your project:
+
+`yarn add gluegun@next`
+
+Everytime run you update, it'll grab the latest published version.

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "lerna": "2.2.0",
-  "version": "1.0.0"
+  "version": "2.0.0-alpha.1"
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "description": "Tack stuff on to your code base.",
   "scripts": {
     "lint": "lerna run lint",
-    "test": "lerna run test",
-    "bootstrap": "lerna bootstrap",
+    "test": "lerna exec yarn test -- -s",
+    "clean": "lerna clean --yes",
+    "bootstrap": "lerna bootstrap --yes",
     "publish": "lerna publish"
   },
   "author": "hello@infinite.red",

--- a/packages/gluegun-cli/package.json
+++ b/packages/gluegun-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gluegun-cli",
-  "version": "1.0.0",
+  "version": "2.0.0-alpha.1",
   "description": "Time to get your glue on.",
   "bin": {
     "gluegun": "bin/gluegun"
@@ -24,7 +24,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "gluegun": "^1.0.0"
+    "gluegun": "^2.0.0-alpha.1"
   },
   "devDependencies": {
     "ava": "^0.19.0",

--- a/packages/gluegun/package.json
+++ b/packages/gluegun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gluegun",
-  "version": "1.0.0",
+  "version": "2.0.0-alpha.1",
   "description": "Build yourself a pluggable CLI.",
   "main": "src/index.js",
   "repository": "infinitered/gluegun",


### PR DESCRIPTION
@GantMan and I both have projects we want to use 2.0 in, so I pushed it out the `next` dist-tag.

`yarn` is still messed up for publishing.  I've `yarn login`... but no luck. I'll figure this out later.

I've documented this process for you.  I'll cut down the steps next time I publish because I'll use `npm` next time.  

lol.