### PR TITLE
missing type pass along of semver

### DIFF
--- a/packages/gluegun/gluegun.d.ts
+++ b/packages/gluegun/gluegun.d.ts
@@ -626,6 +626,7 @@ export interface GluegunSemver {
   satisfies(version: string, inVersion: string): boolean
   gt(version: string, isGreaterThanVersion: string): boolean
   lt(version: string, isLessThanVersion: string): boolean
+  validRange(range: string): boolean | null
 }
 
 export interface GluegunHttp {


### PR DESCRIPTION
Merge this one for now, but.....

seems there must be a better way.  Perhaps:
https://github.com/DefinitelyTyped/tsd/blob/master/typings/semver/semver.d.ts