### PR TITLE
Properly stub colors and color types

### DIFF
--- a/packages/gluegun/gluegun.d.ts
+++ b/packages/gluegun/gluegun.d.ts
@@ -588,6 +588,7 @@ export interface GluegunPrintUtils {
    * Colors as seen from colors.js.
    */
   colors: any
+  color: any
 }
 
 /**


### PR DESCRIPTION
As you can see here:
https://github.com/infinitered/gluegun/blob/4cf9b6d5067e0bb0fb3619dbb5ef489536966fb2/packages/gluegun/src/core-extensions/print-extension.js#L70

Colors is also color