### PR TITLE
v2.0.0-alpha.3

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "lerna": "2.4.0",
-  "version": "2.0.0-alpha.2"
+  "version": "2.0.0-alpha.3"
 }

--- a/packages/gluegun-cli/package.json
+++ b/packages/gluegun-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gluegun-cli",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "Time to get your glue on.",
   "bin": {
     "gluegun": "bin/gluegun"
@@ -24,7 +24,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "gluegun": "^2.0.0-alpha.2"
+    "gluegun": "^2.0.0-alpha.3"
   },
   "devDependencies": {
     "ava": "^0.22.0",

--- a/packages/gluegun/package.json
+++ b/packages/gluegun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gluegun",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "Build yourself a pluggable CLI.",
   "main": "src/index.js",
   "repository": "infinitered/gluegun",


### PR DESCRIPTION
`2.0.0-alpha.3` is now available on `npm`.

```sh
yarn info gluegun dist-tags                                                                                                                                                                                

yarn info v1.2.1
{ latest: '1.0.0',
  next: '2.0.0-alpha.3' }
```