### PR TITLE
Negate test files by default

### DIFF
--- a/packages/gluegun/gluegun.d.ts
+++ b/packages/gluegun/gluegun.d.ts
@@ -852,21 +852,22 @@ export interface GluegunLoadOptions {
   hidden?: boolean
 
   /**
-   * The file pattern to use when auto-detecting commands. The default is `*.js`.
+   * The file pattern to use when auto-detecting commands. The default is [`*.js`, `!*.test.js`].
+   * The second matcher excludes test files with that pattern.
    *
-   * If you are using `ts-node`, you can switch this to `*.ts` to pick up your
+   * If you are using `ts-node`, you can switch this to [`*.ts`, `!*.test.ts`] to pick up your
    * TypeScript-based commands.
    */
-  commandFilePattern?: string
+  commandFilePattern?: string[]
 
   /**
    * The file pattern is used when auto-detecting gluegun extensions.  The default
-   * is `*.js`.
+   * is [`*.js`, `!*.test.js`].
    *
-   * If you are using `ts-node`, you can switch this to `*.ts` to pick up your
+   * If you are using `ts-node`, you can switch this to [`*.ts`, `!*.test.ts`] to pick up your
    * TypeScript-based extensions.
    */
-  extensionFilePattern?: string
+  extensionFilePattern?: string[]
 }
 
 export interface GluegunMultiLoadOptions {

--- a/packages/gluegun/src/domain/runtime-plugins.test.js
+++ b/packages/gluegun/src/domain/runtime-plugins.test.js
@@ -5,7 +5,7 @@ test('loads all sub-directories', t => {
   const r = new Runtime()
   r.loadAll(`${__dirname}/../fixtures/good-plugins`)
 
-  t.is(12, r.plugins.length)
+  t.is(13, r.plugins.length)
 })
 
 test('matches sub-directories', t => {

--- a/packages/gluegun/src/fixtures/good-plugins/excluded/commands/bar.js
+++ b/packages/gluegun/src/fixtures/good-plugins/excluded/commands/bar.js
@@ -1,0 +1,4 @@
+module.exports = {
+  name: 'bar',
+  run: () => {}
+}

--- a/packages/gluegun/src/fixtures/good-plugins/excluded/commands/foo.js
+++ b/packages/gluegun/src/fixtures/good-plugins/excluded/commands/foo.js
@@ -1,0 +1,4 @@
+module.exports = {
+  name: 'foo',
+  run: () => {}
+}

--- a/packages/gluegun/src/fixtures/good-plugins/excluded/commands/foo.test.js
+++ b/packages/gluegun/src/fixtures/good-plugins/excluded/commands/foo.test.js
@@ -1,0 +1,1 @@
+module.exports = () => { return `I'm not a command, ignore me.` }

--- a/packages/gluegun/src/fixtures/good-plugins/excluded/extensions/baz-extension.js
+++ b/packages/gluegun/src/fixtures/good-plugins/excluded/extensions/baz-extension.js
@@ -1,0 +1,3 @@
+module.exports = (context) => {
+  context.baz = true
+}

--- a/packages/gluegun/src/fixtures/good-plugins/excluded/extensions/baz-extension.test.js
+++ b/packages/gluegun/src/fixtures/good-plugins/excluded/extensions/baz-extension.test.js
@@ -1,0 +1,1 @@
+module.exports = () => { return `I'm not an extension, ignore me.` }

--- a/packages/gluegun/src/loaders/toml-plugin-loader.js
+++ b/packages/gluegun/src/loaders/toml-plugin-loader.js
@@ -4,7 +4,7 @@ const loadCommandFromFile = require('./command-loader')
 const loadExtensionFromFile = require('./extension-loader')
 const { isNotDirectory, isFile } = require('../utils/filesystem-utils')
 const { isBlank } = require('../utils/string-utils')
-const { assoc, map, complement, endsWith } = require('ramda')
+const { assoc, map } = require('ramda')
 const toml = require('toml')
 
 /**
@@ -18,8 +18,8 @@ function loadFromDirectory (directory, options = {}) {
 
   const {
     brand = 'gluegun',
-    commandFilePattern = '*.js',
-    extensionFilePattern = '*.js',
+    commandFilePattern = [`*.js`, `!*.test.js`],
+    extensionFilePattern = [`*.js`, `!*.test.js`],
     hidden = false,
     name
   } = options
@@ -56,7 +56,6 @@ function loadFromDirectory (directory, options = {}) {
     const commands = jetpackPlugin
       .cwd('commands')
       .find({ matching: commandFilePattern, recursive: true })
-      .filter(complement(endsWith('.test.js')))
 
     plugin.commands = map(
       file => loadCommandFromFile(`${directory}/commands/${file}`),
@@ -71,7 +70,6 @@ function loadFromDirectory (directory, options = {}) {
     const extensions = jetpackPlugin
       .cwd('extensions')
       .find({ matching: extensionFilePattern, recursive: false })
-      .filter(complement(endsWith('.test.js')))
 
     plugin.extensions = map(
       file => loadExtensionFromFile(`${directory}/extensions/${file}`),

--- a/packages/gluegun/src/loaders/toml-plugin-loader.test.js
+++ b/packages/gluegun/src/loaders/toml-plugin-loader.test.js
@@ -103,3 +103,13 @@ test('supports hidden plugins & commands', t => {
   t.true(plugin.commands[1].hidden)
   t.true(plugin.commands[2].hidden)
 })
+
+test('ignores test files', t => {
+  const dir = `${__dirname}/../fixtures/good-plugins/excluded`
+  const plugin = load(dir)
+
+  t.is(plugin.commands.length, 2)
+  t.is(plugin.commands[0].name, 'bar')
+  t.is(plugin.commands[1].name, 'foo')
+  t.is(plugin.extensions.length, 1)
+})


### PR DESCRIPTION
Fixes #247. You can override this by providing your own `commandFilePattern` or `extensionFilePattern`, which is now recommended to be an array of strings instead of just a string.