### PR TITLE
Switches patching.exists to use includes when string

### DIFF
--- a/src/core-extensions/patching-extension.js
+++ b/src/core-extensions/patching-extension.js
@@ -20,7 +20,7 @@ function attach (context) {
   async function exists (filename, findPattern) {
     // sanity check the filename
     if (isNotString(filename) || isNotFile(filename)) {
-      false
+      return false
     }
 
     // sanity check the findPattern

--- a/src/core-extensions/patching-extension.js
+++ b/src/core-extensions/patching-extension.js
@@ -1,5 +1,7 @@
 const jetpack = require('fs-jetpack')
-const { isFile } = require('../utils/filesystem-utils')
+const { isFile, isNotFile } = require('../utils/filesystem-utils')
+const { isNotString } = require('../utils/string-utils')
+const { is, test } = require('ramda')
 
 /**
  * Builds the patching feature.
@@ -9,21 +11,35 @@ const { isFile } = require('../utils/filesystem-utils')
 function attach (context) {
 
   /**
-   * Identifies if something exists in a file
+   * Identifies if something exists in a file. Async.
    *
-   * @param  {string}  filename     The path to the file we'll be scanning.
-   * @param  {string}  findPattern  The case sensitive string or RegExp that identifies existence.
-   * @return {boolean}              Boolean of success that findPattern was in file.
+   * @param {string} filename The path to the file we'll be scanning.
+   * @param {string} findPattern The case sensitive string or RegExp that identifies existence.
+   * @return {Promise<boolean>} Boolean of success that findPattern was in file.
    */
   async function exists (filename, findPattern) {
-    let contents = await readFile(filename)
-
-    if (typeof contents !== 'string') {
-      contents = JSON.stringify(contents)
+    // sanity check the filename
+    if (isNotString(filename) || isNotFile(filename)) {
+      false
     }
 
-    let finder = typeof findPattern === 'string' ? new RegExp(`.*${findPattern}.*`, '') : findPattern
-    return !!contents.match(finder)
+    // sanity check the findPattern
+    const patternIsString = typeof findPattern === 'string'
+    if (!findPattern instanceof RegExp && !patternIsString) {
+      return false
+    }
+
+    // read from jetpack -- they guard against a lot of the edge
+    // cases and return nil if problematic
+    const contents = await jetpack.readAsync(filename)
+
+    // only let the strings pass
+    if (isNotString(contents)) {
+      return false
+    }
+
+    // do the appropriate check
+    return patternIsString ? contents.includes(findPattern) : test(findPattern, contents)
   }
 
   /**

--- a/src/core-extensions/patching-extension.test.js
+++ b/src/core-extensions/patching-extension.test.js
@@ -24,37 +24,19 @@ test.beforeEach(t => {
   t.context.textFile = tempWrite.sync(TEXT_STRING)
 })
 
-test('exists - checks a JSON file for a string', async t => {
-  const configFile = tempWrite.sync(CONFIG_STRING, '.json')
-  const exists = await patching.exists(configFile, 'test')
-  t.truthy(exists)
-})
-
 test('exists - checks a TEXT file for a string', async t => {
   const exists = await patching.exists(t.context.textFile, 'words')
-  t.truthy(exists)
-})
-
-test('exists - checks a JSON file for a short form regex', async t => {
-  const configFile = tempWrite.sync(CONFIG_STRING, '.json')
-  const exists = await patching.exists(configFile, /test/)
-  t.truthy(exists)
+  t.true(exists)
 })
 
 test('exists - checks a TEXT file for a short form regex', async t => {
   const exists = await patching.exists(t.context.textFile, /ords\b/)
-  t.truthy(exists)
-})
-
-test('exists - checks a JSON file for a RegExp', async t => {
-  const configFile = tempWrite.sync(CONFIG_STRING, '.json')
-  const exists = await patching.exists(configFile, new RegExp('Test', 'i'))
-  t.truthy(exists)
+  t.true(exists)
 })
 
 test('exists - checks a TEXT file for a RegExp', async t => {
   const exists = await patching.exists(t.context.textFile, new RegExp('Word', 'i'))
-  t.truthy(exists)
+  t.true(exists)
 })
 
 test('update - updates a JSON file', async t => {
@@ -69,7 +51,7 @@ test('update - updates a JSON file', async t => {
   })
 
   // returned the updated object
-  t.truthy(updated.mutated)
+  t.true(updated.mutated)
   t.is(updated.test, 'what???')
   t.is(updated.test2, 'never')
 
@@ -102,7 +84,7 @@ test('update - cancel updating a file', async t => {
   })
 
   // returned false
-  t.falsy(updated)
+  t.false(updated)
 
   // file was not altered
   const newContents = await jetpack.read(t.context.textFile, 'utf8')


### PR DESCRIPTION
@jamonholmgren pointed out that the new `exists` function should check via `includes` when `findPattern` is a string.

Also did a few small uninteresting changes as well:

* switched to `jetpack.read` to load the file instead of `readFile` since don't need `JSON` 
* ^ removed corresponding JSON tests
* added a few early exit sanity checks


