### PR TITLE
Exposing print utils at the top level. Closes #208.

### DIFF
--- a/gluegun.d.ts
+++ b/gluegun.d.ts
@@ -589,6 +589,10 @@ export interface GluegunPrintUtils {
   newline: () => void
   table: (data: any, options: any) => void
   /**
+   * An `ora` spinner.
+   */
+  spin(options: any): any
+  /**
    * Colors as seen from colors.js.
    */
   colors: any

--- a/src/core-extensions/print-extension.js
+++ b/src/core-extensions/print-extension.js
@@ -1,6 +1,5 @@
 const print = require('../utils/print')
 const printCommands = require('../utils/cli/print-commands')
-const ora = require('ora')
 
 /**
  * Extensions to print to the console.
@@ -49,7 +48,7 @@ function attach (context) {
    * @returns The spinner.
    */
   function spin (config) {
-    return ora(config).start()
+    return print.spin(config)
   }
 
   // attach the feature set
@@ -64,7 +63,6 @@ function attach (context) {
     xmark,
     spin,
     printCommands,
-
     table: print.table,
     newline: print.newline,
     color: colors

--- a/src/core-extensions/print-extension.test.js
+++ b/src/core-extensions/print-extension.test.js
@@ -1,0 +1,48 @@
+const test = require('ava')
+let context = {};
+require('./print-extension')(context)
+
+const { print } = context;
+
+
+test('info', t => {
+  t.is(typeof print.info, 'function')
+})
+
+test('warning', t => {
+  t.is(typeof print.warning, 'function')
+})
+
+test('success', t => {
+  t.is(typeof print.success, 'function')
+})
+
+test('error', t => {
+  t.is(typeof print.error, 'function')
+})
+
+test('debug', t => {
+  t.is(typeof print.debug, 'function')
+})
+
+test('newline', t => {
+  t.is(typeof print.newline, 'function')
+})
+
+test('table', t => {
+  t.is(typeof print.table, 'function')
+})
+
+test('spin', t => {
+  t.is(typeof print.spin, 'function')
+})
+
+test('colors', t => {
+  t.is(typeof print.colors.highlight, 'function')
+  t.is(typeof print.colors.info, 'function')
+  t.is(typeof print.colors.warning, 'function')
+  t.is(typeof print.colors.success, 'function')
+  t.is(typeof print.colors.error, 'function')
+  t.is(typeof print.colors.line, 'function')
+  t.is(typeof print.colors.muted, 'function')
+})

--- a/src/utils/print.js
+++ b/src/utils/print.js
@@ -1,5 +1,6 @@
 const colors = require('colors')
 const AsciiTable = require('ascii-table')
+const ora = require('ora')
 
 /**
  * Sets the color scheme.
@@ -117,6 +118,16 @@ function success (message) {
   console.log(colors.success(message))
 }
 
+/**
+   * Creates a spinner and starts it up.
+   *
+   * @param {string|Object} config The text for the spinner or an ora configuration object.
+   * @returns The spinner.
+   */
+function spin(config) {
+  return ora(config).start()
+}
+
 module.exports = {
   info,
   warning,
@@ -127,5 +138,6 @@ module.exports = {
   divider,
   newline,
   table,
+  spin,
   colors
 }

--- a/src/utils/print.test.js
+++ b/src/utils/print.test.js
@@ -85,6 +85,12 @@ test.serial('table', t => {
   t.is(spyLog.args[i++][0], '  liam      5  \n  matthew   2  ')
 })
 
+test.only('spin', t => {
+  t.is(typeof print.spin, 'function')
+  const spinner = print.spin()
+  t.is(typeof spinner.stop, 'function')
+})
+
 test.serial('colors', t => {
   t.is(typeof print.colors.highlight, 'function')
   t.is(typeof print.colors.info, 'function')


### PR DESCRIPTION
This PR:

- Adds some basic tests for `print-extension`. Not sure how far you wanted to go down that path or not and since Ava was giving me grief I got a bit lazy but at least wanted to test that the interface is defined.

- Adds a test for `print.spin`. Again, not sure how best to test this... deferring to you for advice.
- Exposes `spin` at the top `print` module level and `print-extension` now just uses that.