### PR TITLE
switch out tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gluegun",
-  "version": "2.0.0-alpha.13",
+  "version": "2.0.0-alpha.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -107,19 +107,12 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
       "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
-      "dev": true,
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
         "fast-json-stable-stringify": "2.0.0",
         "json-schema-traverse": "0.3.1"
       }
-    },
-    "ajv-keywords": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-      "dev": true
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -528,11 +521,6 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
-    },
-    "ascii-table": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/ascii-table/-/ascii-table-0.0.9.tgz",
-      "integrity": "sha1-BqZgTWpV1L9BqaR9mHLXp42jHnM="
     },
     "asn1": {
       "version": "0.2.3",
@@ -1724,8 +1712,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "co-with-promise": {
       "version": "4.6.0",
@@ -1764,7 +1751,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1772,8 +1758,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
       "version": "1.1.2",
@@ -2403,7 +2388,6 @@
         "shelljs": "0.7.8",
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1",
-        "table": "3.8.3",
         "text-table": "0.2.0",
         "user-home": "2.0.0"
       },
@@ -2837,8 +2821,7 @@
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
-      "dev": true
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
     },
     "fast-diff": {
       "version": "1.1.2",
@@ -2849,8 +2832,7 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -3246,8 +3228,7 @@
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-      "dev": true
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "has-value": {
       "version": "1.0.0",
@@ -3925,8 +3906,7 @@
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -4310,8 +4290,7 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -8112,7 +8091,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-      "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
       }
@@ -8391,34 +8369,48 @@
       "dev": true
     },
     "table": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
-      "dev": true,
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
+        "ajv": "5.3.0",
+        "ajv-keywords": "2.1.1",
+        "chalk": "2.3.0",
         "lodash": "4.17.4",
-        "slice-ansi": "0.0.4",
+        "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
       },
       "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
+        "ajv-keywords": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "color-convert": "1.9.0"
           }
         },
-        "slice-ansi": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-          "dev": true
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "apisauce": "^0.14.1",
     "app-module-path": "^2.2.0",
-    "ascii-table": "^0.0.9",
     "colors": "^1.1.2",
     "cross-spawn": "^5.1.0",
     "ejs": "^2.5.7",
@@ -71,6 +70,7 @@
     "ramda": "^0.24.1",
     "ramdasauce": "^2.1.0",
     "semver": "^5.3.0",
+    "table": "^4.0.2",
     "toml": "^2.3.2",
     "which": "^1.2.14"
   },

--- a/src/utils/print.js
+++ b/src/utils/print.js
@@ -1,5 +1,5 @@
 const colors = require('colors')
-const AsciiTable = require('ascii-table')
+const { table: asciiTable, getBorderCharacters } = require('table')
 const ora = require('ora')
 
 /**
@@ -40,10 +40,40 @@ function divider () {
  * @param {{}} object The object to turn into a table.
  */
 function table (data, options) {
-  const t = new AsciiTable()
-  t.addRowMatrix(data)
-  t.removeBorder()
-  console.log(t.toString())
+  let tableDesign
+  if (options) {
+    if (options.markdown) {
+      // hopefully a new template coming soon
+      // https://github.com/gajus/table/issues/53
+      tableDesign = asciiTable(data, {
+        border: {
+          topBody: '',
+          topJoin: '',
+          topLeft: '',
+          topRight: '',
+          bottomBody: '',
+          bottomJoin: '',
+          bottomLeft: '',
+          bottomRight: '',
+          bodyLeft: '|',
+          bodyRight: '|',
+          bodyJoin: '|',
+          joinBody: '-',
+          joinLeft: '|',
+          joinRight: '|',
+          joinJoin: '|'
+        },
+        drawHorizontalLine: (index) => index === 1,
+        ...options
+      })
+    } else {
+      tableDesign = asciiTable(data, options)
+    }
+  } else {
+    // default no frills table
+    tableDesign = asciiTable(data, {border: getBorderCharacters(`void`), drawHorizontalLine: () => false})
+  }
+  console.log(tableDesign)
 }
 
 /**

--- a/src/utils/print.test.js
+++ b/src/utils/print.test.js
@@ -82,7 +82,11 @@ test.serial('table', t => {
     ['matthew', '2']
   ]
   print.table(data)
-  t.is(spyLog.args[i++][0], '  liam      5  \n  matthew   2  ')
+  t.is(spyLog.args[i++][0], ' liam     5 \n matthew  2 \n')
+  print.table(data, {})
+  t.is(spyLog.args[i++][0], '╔═════════╤═══╗\n║ liam    │ 5 ║\n╟─────────┼───╢\n║ matthew │ 2 ║\n╚═════════╧═══╝\n')
+  print.table(data, {markdown: true})
+  t.is(spyLog.args[i++][0], '| liam    | 5 |\n|---------|---|\n| matthew | 2 |\n')
 })
 
 test.serial('spin', t => {


### PR DESCRIPTION
### In this PR
Remove ASCII table and use "Table"

Keep the old table format by default, but allow so much more.

As the name ASCII implies, it sucks at Unicode characters.

Secondly, I wanted to do some advanced table dancing... wait.. wut?

But seriously, I want a Markdown table print option.  So I switched to a configurable table, and configured it.  Added tests for the 3 default modes and kept default behavior the same.

-------
closes #207 