### PR TITLE
Update npm install instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ If you want to have **your** CLI...
 Just run the `gluegun` CLI like this:
 
 ```
-$ npm install -g gluegun-cli
+$ npm install -g gluegun@next
 $ gluegun new movies
 $ cd movies
 $ npm install


### PR DESCRIPTION
The correct command is now `npm install -g gluegun`.
Change from `npm install -g gluegun-cli`