### PR TITLE
Fix typo

### DIFF
--- a/docs/context-filesystem.md
+++ b/docs/context-filesystem.md
@@ -7,7 +7,7 @@ file system.  All jetpack-based functions have an equivalent `*Async` version if
 This value is the path separator `\` or `/` depending on the OS.
 
 ```js
-context.filesystem.seperator // '/' on posix but '\' on windows
+context.filesystem.separator // '/' on posix but '\' on windows
 ```
 
 ## eol


### PR DESCRIPTION
Found a typo in the `context-filesystem.js` docs ;)