### PR TITLE
🚑 Changes property spread into Object.assign

### DIFF
--- a/src/utils/print.js
+++ b/src/utils/print.js
@@ -20,12 +20,11 @@ const CLI_TABLE_COMPACT = {
   middle: ' '
 }
 
-const CLI_TABLE_MARKDOWN = {
-  ...CLI_TABLE_COMPACT,
+const CLI_TABLE_MARKDOWN = Object.assign({}, CLI_TABLE_COMPACT, {
   left: '|',
   right: '|',
   middle: '|'
-}
+})
 
 /**
  * Sets the color scheme.


### PR DESCRIPTION
Since we're targeting 7.6 of node we can't use the `{...thing}` feature.

Fixes #276
