### PR TITLE
Properly resolve plugin commands

### DIFF
--- a/src/domain/runtime.js
+++ b/src/domain/runtime.js
@@ -251,7 +251,6 @@ class Runtime {
   /**
    * Find the command for this commandPath.
    *
-   * @param {Context} context         Current runtime context
    * @param {string[]} commandPath    The command to find.
    * @returns {{}}                    An object containing a Command & rest of arguments, otherwise null.
    */

--- a/src/domain/runtime.js
+++ b/src/domain/runtime.js
@@ -258,7 +258,8 @@ class Runtime {
     let targetPlugin, targetCommand, rest
 
     // start with defaultPlugin, then move on to the others
-    const plugins = [this.defaultPlugin, ...this.plugins.filter(p => p !== this.defaultPlugin)]
+    const otherPlugins = this.plugins.filter(p => p !== this.defaultPlugin)
+    const plugins = [this.defaultPlugin, ...otherPlugins].filter(p => !isNil(p))
 
     targetPlugin = find(plugin => {
       if (isNil(plugin) || isNilOrEmpty(plugin.commands)) return { command: null, args: [] }


### PR DESCRIPTION
Fixes #290.

Prior to this, the code was doing some strange plugin resolve and then searching for a command in that plugin.

Now, we look through every plugin's commands until we find one that matches, starting with the default plugin (the main CLI).
