### PR TITLE
Reworks parameters again, fixes issue #288

### DIFF
--- a/docs/context-parameters.md
+++ b/docs/context-parameters.md
@@ -1,24 +1,23 @@
-Information about how the command was invoked. Most of the time this is from the comand line, however, 
-it is possible to call it from the API if you're writing your own CLI.
-
-Check out this example of creating a new Reactotron plugin.
+Information about how the command was invoked. Check out this example of creating a new Reactotron plugin.
 
 ```sh
-glue reactotron plugin MyAwesomePlugin full --comments --lint standard
+gluegun reactotron plugin MyAwesomePlugin full --comments --lint standard
 ```
 
-| name           | type   | purpose                           | from the example above               |
-| -------------- | ------ | --------------------------------- | ------------------------------------ |
-| **pluginName** | string | the pluginName used               | `'reactotron'`                       |
-| **command**    | string | the command used                  | `'plugin'`                           |
-| **string**     | string | the command arguments as a string | `'MyAwesomePlugin full'`             |
-| **array**      | array  | the command arguments as an array | `['MyAwesomePlugin', 'full']`        |
-| **first**      | string | the 1st argument                  | `'MyAwesomePlugin'`                  |
-| **second**     | string | the 2nd argument                  | `'full'`                             |
-| **third**      | string | the 3rd argument                  | `undefined`                          |
-| **options**    | object | command line options              | `{comments: true, lint: 'standard'}` |
+| name        | type   | purpose                           | from the example above               |
+| ----------- | ------ | --------------------------------- | ------------------------------------ |
+| **plugin**  | string | the plugin used                   | `'reactotron'`                       |
+| **command** | string | the command used                  | `'plugin'`                           |
+| **string**  | string | the command arguments as a string | `'do thing'`                         |
+| **array**   | array  | the command arguments as an array | `['MyAwesomePlugin', 'full']`        |
+| **first**   | string | the 1st argument                  | `'MyAwesomePlugin'`                  |
+| **second**  | string | the 2nd argument                  | `'full'`                             |
+| **third**   | string | the 3rd argument                  | `undefined`                          |
+| **options** | object | command line options              | `{comments: true, lint: 'standard'}` |
+| **argv**    | object | raw argv                          |                                      |
 
 ## options
+
 Options are the command line flags. Always exists however it may be empty.
 
 ```sh
@@ -26,12 +25,13 @@ gluegun say hello --loud -v --wave furiously
 ```
 
 ```js
-module.exports = async function (context) {
+module.exports = async function(context) {
   context.parameters.options // { loud: true, v: true, wave: 'furiously' }
 }
 ```
 
 ## string
+
 Everything else after the command as a string.
 
 ```sh
@@ -39,12 +39,13 @@ gluegun say hello there
 ```
 
 ```js
-module.exports = async function (context) {
+module.exports = async function(context) {
   context.parameters.string // 'hello there'
 }
 ```
 
 ## array
+
 Everything else after the command, but as an array.
 
 ```sh
@@ -52,13 +53,14 @@ gluegun reactotron plugin full
 ```
 
 ```js
-module.exports = async function (context) {
+module.exports = async function(context) {
   context.parameters.array // ['plugin', 'full']
 }
 ```
 
 ## first / .second / .third
-The first, second, and third element in `array`. It is provided as a shortcut, and there isn't one, 
+
+The first, second, and third element in `array`. It is provided as a shortcut, and there isn't one,
 this will be `undefined`.
 
 ```sh
@@ -66,9 +68,9 @@ gluegun reactotron plugin full
 ```
 
 ```js
-module.exports = async function (context) {
-  context.parameters.first  // 'plugin'
+module.exports = async function(context) {
+  context.parameters.first // 'plugin'
   context.parameters.second // 'full'
-  context.parameters.third  // undefined
+  context.parameters.third // undefined
 }
 ```

--- a/src/domain/runtime-parameters.test.js
+++ b/src/domain/runtime-parameters.test.js
@@ -4,7 +4,7 @@ const Runtime = require('./runtime')
 test('can pass arguments', async t => {
   const r = new Runtime()
   r.load(`${__dirname}/../fixtures/good-plugins/args`)
-  const { command, parameters } = await r.run('args hello steve kellock', { caps: false })
+  const { command, parameters } = await r.run('hello steve kellock', { caps: false })
 
   t.is(parameters.string, 'steve kellock')
   t.is(parameters.first, 'steve')
@@ -20,7 +20,7 @@ test('can pass arguments', async t => {
 test('can pass arguments, even with nested alias', async t => {
   const r = new Runtime()
   r.load(`${__dirname}/../fixtures/good-plugins/nested`)
-  const { command, parameters } = await r.run('nested t f jamon holmgren', { chocolate: true })
+  const { command, parameters } = await r.run('t f jamon holmgren', { chocolate: true })
 
   t.is(parameters.string, 'jamon holmgren')
   t.is(parameters.first, 'jamon')
@@ -31,4 +31,18 @@ test('can pass arguments, even with nested alias', async t => {
   t.deepEqual(parameters.array, ['jamon', 'holmgren'])
   t.deepEqual(parameters.options, { chocolate: true })
   t.deepEqual(command.commandPath, ['thing', 'foo'])
+})
+
+test('can pass arguments with mixed options', async t => {
+  const r = new Runtime()
+  r.load(`${__dirname}/../fixtures/good-plugins/args`)
+  const { command, parameters } = await r.run('--chocolate=true --foo -n 1 hello steve kellock')
+  t.deepEqual(command.commandPath, ['hello'])
+  t.is(parameters.string, 'steve kellock')
+  t.is(parameters.first, 'steve')
+  t.is(parameters.second, 'kellock')
+  t.is(parameters.command, 'hello')
+  t.is(parameters.options.foo, true)
+  t.is(parameters.options.n, 1)
+  t.is(parameters.options.chocolate, 'true')
 })

--- a/src/domain/runtime-run-good.test.js
+++ b/src/domain/runtime-run-good.test.js
@@ -20,7 +20,7 @@ test('runs an aliased command', async t => {
 test('runs a nested command', async t => {
   const r = new Runtime()
   r.load(`${__dirname}/../fixtures/good-plugins/nested`)
-  const context = await r.run('nested thing foo')
+  const context = await r.run('thing foo')
   t.truthy(context.command)
   t.is(context.command.name, 'foo')
   t.deepEqual(context.command.commandPath, ['thing', 'foo'])

--- a/src/utils/cli/normalize-params.js
+++ b/src/utils/cli/normalize-params.js
@@ -1,20 +1,28 @@
 const minimist = require('minimist')
+const { merge } = require('ramda')
+
+function parseParams (argv, extraOpts = {}) {
+  // chop it up minimist!
+  const parsed = minimist(argv)
+  const array = parsed._.slice()
+  delete parsed._
+  const options = merge(parsed, extraOpts)
+  return { array, options }
+}
 
 /**
- * Parses the command-line arguments into a normalized object.
+ * Constructs the parameters object.
  *
- * @param {string} plugin     Plugin name
- * @param {string} command    The command being run
- * @param {[]} args           List of rest of command arguments _after_ the command
- * @param {[]} argv           List of command arguments
+ * @param {{}} params         Provided parameters
  * @return {{}}               An object with normalized parameters
  */
-function normalizeParams (plugin, command, restArgs, argv = []) {
-  // chop it up minimist!
-  const options = minimist(argv)
-  const array = restArgs
-  delete options._
-  const raw = array.join(' ')
+function createParams (params) {
+  // make a copy of the args so we can mutate it
+  const array = params.array.slice()
+
+  // Remove the first two elements from the array if they're the plugin and command
+  if (array[0] === params.plugin) array.shift()
+  if (array[0] === params.command) array.shift()
 
   const first = array[0]
   const second = array[1]
@@ -24,18 +32,13 @@ function normalizeParams (plugin, command, restArgs, argv = []) {
   const string = array.join(' ')
 
   // :shipit:
-  return {
-    plugin,
-    command,
+  return Object.assign(params, {
+    array,
     first,
     second,
     third,
-    raw,
-    string,
-    array,
-    options,
-    argv
-  }
+    string
+  })
 }
 
-module.exports = normalizeParams
+module.exports = { parseParams, createParams }


### PR DESCRIPTION
This removes a lot of the janky manual parsing of command line arguments that we were doing before and uses `minimist` for all of it.

My confidence level that this works across all situations is not super high, since I did rewrite a fair amount of critical path code here. Tests all pass, and in fact some jankiness with the tests is now looking much more like I'd expect, so that's a good sign.