### PR TITLE
Remove previous listeners to avoid stacking up multiple. Fixes #295

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ if (!sniff.isNewEnough) {
 }
 
 // we want to see real exceptions with backtraces and stuff
+process.removeAllListeners('unhandledRejection')
 process.on('unhandledRejection', up => {
   throw up
 })


### PR DESCRIPTION
@skellock reported an issue when running `jest --watch` where this error was reported:

```
(node:17181) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 unhandledRejection listeners added. Use emitter.setMaxListeners() to increase limit
```

By removing all listeners prior to [re]adding the listener, we avoid this issue.