### PR TITLE
Fixes failed template copy from new

### DIFF
--- a/src/cli/commands/new.js
+++ b/src/cli/commands/new.js
@@ -40,7 +40,6 @@ module.exports = {
     const files = [
       'docs/commands.md.ejs',
       'docs/plugins.md.ejs',
-      'src/commands/help.js.ejs',
       'src/commands/generate.js.ejs',
       'src/extensions/cli-extension.js.ejs',
       'src/templates/model.js.ejs.ejs',

--- a/src/cli/commands/new.test.js
+++ b/src/cli/commands/new.test.js
@@ -91,7 +91,6 @@ test('generates properly', async t => {
   const DEFAULT_FILES = [
     ['docs/commands.md.ejs', 'docs/commands.md'],
     ['docs/plugins.md.ejs', 'docs/plugins.md'],
-    ['src/commands/help.js.ejs', 'src/commands/help.js'],
     ['src/commands/generate.js.ejs', 'src/commands/generate.js'],
     ['src/extensions/cli-extension.js.ejs', 'src/extensions/cli-extension.js'],
     ['src/templates/model.js.ejs.ejs', 'src/templates/model.js.ejs'],
@@ -156,7 +155,6 @@ test('generates with typescript', async t => {
   const DEFAULT_FILES = [
     ['docs/commands.md.ejs', 'docs/commands.md'],
     ['docs/plugins.md.ejs', 'docs/plugins.md'],
-    ['src/commands/help.js.ejs', 'src/commands/help.ts'],
     ['src/commands/generate.js.ejs', 'src/commands/generate.ts'],
     ['src/extensions/cli-extension.js.ejs', 'src/extensions/cli-extension.ts'],
     ['src/templates/model.js.ejs.ejs', 'src/templates/model.ts.ejs'],


### PR DESCRIPTION
Was playing with master, and failed to create a new project.

I think we have a bigger problem that tests didn't catch it.  Might need to circle back at some point for basic integration tests.