### PR TITLE
Adds new meta extension, adds commandInfo & version to it

### DIFF
--- a/docs/context-api.md
+++ b/docs/context-api.md
@@ -16,8 +16,8 @@ Here's what's available inside the `context` object you see all over Gluegun.
 
 | name           | provides the...                                    | 3rd party                      |
 | -------------- | -------------------------------------------------- | ------------------------------ |
-| **config**     | configuration options from the app or plugin       |
-| **version**    | function to retrieve your CLI's current version    |                                |
+| **meta**       | information about the currently running CLI        |                                |
+| **config**     | configuration options from the app or plugin       |                                |
 | **filesystem** | ability to copy, move & delete files & directories | fs-jetpack                     |
 | **http**       | ability to talk to the web                         | apisauce                       |
 | **parameters** | command line arguments and options                 | yargs-parser                   |
@@ -37,10 +37,10 @@ module.exports = {
   alias: 'd',
   run: async function(context) {
     // use them like this...
-    context.print.info(context.version())
+    context.print.info(context.meta.version())
 
     // or destructure!
-    const { print: { info }, version } = context
+    const { print: { info }, meta: { version } } = context
     info(version())
   },
 }

--- a/docs/context-meta.md
+++ b/docs/context-meta.md
@@ -1,0 +1,18 @@
+Provides functions for accessing information about the currently running CLI.
+
+## version
+
+Retrieves the currently running CLI's version.
+
+```js
+context.meta.version() // '1.0.0'
+```
+
+## commandInfo
+
+Retrieves information about all of this CLI's commands. You can use this to display a custom help screen, for example.
+
+```js
+const commandInfo = context.meta.commandInfo()
+context.print.table(commandInfo)
+```

--- a/gluegun.d.ts
+++ b/gluegun.d.ts
@@ -54,9 +54,6 @@ export interface GluegunExtension {
  * way to run a command within the system.
  */
 export interface GluegunRunOptions {
-  /** The name of the plugin to run. */
-  pluginName?: string
-
   /**
    * The raw command contains the name of the command plus
    * any named parameters.
@@ -79,6 +76,11 @@ export type GluegunExtensionAttacher = (
   command: string,
   context: GluegunRunContext
 ) => void
+
+export interface GluegunMeta {
+  version: () => string
+  commandInfo: (context: GluegunRunContext) => string[][]
+}
 
 export interface GluegunParameters {
   /**
@@ -978,6 +980,16 @@ export interface GluegunBuilder {
   version(command?: any): GluegunBuilder
 
   /**
+   * Add a default command.
+   */
+  defaultCommand(command?: any): GluegunBuilder
+
+  /**
+   * Add an arbitrary command.
+   */
+  command(command?: any): GluegunBuilder
+
+  /**
    * Creates a runtime.
    *
    * Call this function when you are finished configuring the builder
@@ -1025,3 +1037,6 @@ export const prompt: GluegunPrompt
 
 /** File generation functions. */
 export const template: GluegunTemplate
+
+/** Info about the current CLI. */
+export const meta: GluegunMeta

--- a/src/core-commands/version.js
+++ b/src/core-commands/version.js
@@ -3,6 +3,6 @@ module.exports = {
   alias: 'v',
   dashed: true,
   run: context => {
-    context.print.info(context.version())
+    context.print.info(context.meta.version())
   }
 }

--- a/src/core-extensions/meta-extension.js
+++ b/src/core-extensions/meta-extension.js
@@ -1,0 +1,17 @@
+const { getVersion } = require('../utils/get-version')
+const { commandInfo } = require('../utils/command-info')
+
+/**
+ * Extension that lets you learn more about the currently running CLI.
+ *
+ * @param  {RunContext} context The running context.
+ */
+function attach (context) {
+  context.meta = {
+    version: () => getVersion(context),
+    commandInfo: () => commandInfo(context)
+  }
+  context.version = context.meta.version // easier access to version
+}
+
+module.exports = attach

--- a/src/domain/runtime-extensions.test.js
+++ b/src/domain/runtime-extensions.test.js
@@ -6,5 +6,5 @@ test('loads the core extensions in the right order', t => {
   const r = new Runtime()
   const list = pipe(pluck('name'), join(', '))(r.extensions)
 
-  t.is(list, 'core, strings, print, template, filesystem, semver, system, http, prompt, patching')
+  t.is(list, 'meta, strings, print, template, filesystem, semver, system, http, prompt, patching')
 })

--- a/src/domain/runtime.js
+++ b/src/domain/runtime.js
@@ -23,7 +23,7 @@ const { loadPluginFromDirectory } = require('../loaders/plugin-loader')
 const { resolve } = require('path')
 
 // core extensions
-const addCoreExtension = require('../core-extensions/core-extension')
+const addMetaExtension = require('../core-extensions/meta-extension')
 const addTemplateExtension = require('../core-extensions/template-extension')
 const addPrintExtension = require('../core-extensions/print-extension')
 const addFilesystemExtension = require('../core-extensions/filesystem-extension')
@@ -134,7 +134,7 @@ class Runtime {
    * for extending the core as 3rd party extensions do.
    */
   addCoreExtensions () {
-    this.addExtension('core', addCoreExtension)
+    this.addExtension('meta', addMetaExtension)
     this.addExtension('strings', addStringsExtension)
     this.addExtension('print', addPrintExtension)
     this.addExtension('template', addTemplateExtension)

--- a/src/utils/command-info.js
+++ b/src/utils/command-info.js
@@ -1,0 +1,52 @@
+const { pipe, map, sortBy, prop, propEq, reject, replace, unnest, equals } = require('ramda')
+
+/**
+ * Is this a hidden command?
+ */
+const isHidden = propEq('hidden', true)
+
+/**
+ * Gets the list of plugins.
+ *
+ * @param {RunContext} context     The context
+ * @param {Plugin[]} plugins       The plugins holding the commands
+ * @param {string[]} commandRoot   Optional, only show commands with this root
+ * @return {[string, string]}
+ */
+function commandInfo (context, plugins, commandRoot) {
+  return pipe(
+    reject(isHidden),
+    sortBy(prop('name')),
+    map(p => getListOfCommands(context, p, commandRoot)),
+    unnest
+  )(plugins)
+}
+
+/**
+ * Gets the list of commands for the given plugin.
+ *
+ * @param {RunContext} context     The context
+ * @param {Plugin} plugin          The plugins holding the commands
+ * @param {string[]} commandRoot   Optional, only show commands with this root
+ * @return {[string, string]}
+ */
+function getListOfCommands (context, plugin, commandRoot) {
+  return pipe(
+    reject(isHidden),
+    reject(command => {
+      if (!commandRoot) {
+        return false
+      }
+      return !equals(command.commandPath.slice(0, commandRoot.length), commandRoot)
+    }),
+    map(command => {
+      const alias = command.hasAlias() ? `(${command.aliases.join(', ')})` : ''
+      return [
+        `${command.commandPath.join(' ')} ${alias}`,
+        replace('$BRAND', context.runtime.brand, command.description || '-')
+      ]
+    })
+  )(plugin.commands)
+}
+
+module.exports = { commandInfo }

--- a/src/utils/command-info.js
+++ b/src/utils/command-info.js
@@ -19,7 +19,7 @@ function commandInfo (context, plugins, commandRoot) {
     sortBy(prop('name')),
     map(p => getListOfCommands(context, p, commandRoot)),
     unnest
-  )(plugins)
+  )(plugins || context.runtime.plugins)
 }
 
 /**

--- a/src/utils/command-info.test.js
+++ b/src/utils/command-info.test.js
@@ -1,0 +1,25 @@
+const test = require('ava')
+const { commandInfo } = require('./command-info')
+
+test('commandInfo', t => {
+  const fakeContext = {
+    runtime: {
+      plugins: [
+        {
+          commands: [
+            {
+              name: 'foo',
+              description: 'foo is a command',
+              commandPath: ['foo'],
+              aliases: ['f'],
+              hasAlias: () => true
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  const info = commandInfo(fakeContext)
+  t.deepEqual(info, [['foo (f)', 'foo is a command']])
+})

--- a/src/utils/get-version.js
+++ b/src/utils/get-version.js
@@ -1,5 +1,10 @@
 const jetpack = require('fs-jetpack')
 
+/**
+ * Finds the version for the currently running CLI.
+ *
+ * @param {RunContext} context
+ */
 function getVersion (context) {
   let directory = context.runtime.defaultPlugin && context.runtime.defaultPlugin.directory
   if (!directory) {
@@ -26,13 +31,4 @@ function getVersion (context) {
   throw new Error(`context.version: Unknown CLI version (no package.json found in ${directory}`)
 }
 
-/**
- * Gluegun-specific extensions.
- *
- * @param  {RunContext} context The running context.
- */
-function attach (context) {
-  context.version = () => getVersion(context)
-}
-
-module.exports = attach
+module.exports = { getVersion }


### PR DESCRIPTION
Fixes #148.

I haven't been super happy with the `core-extension` I introduced in an earlier PR, #298. When I thought about it, `version()` and this new `commandInfo()` function are really about the CLI itself. So I decided to create a new extension, `meta`, and move everything there. I'm much happier about it this way.

Note this moves `context.version()` from earlier alphas to `context.meta.version()` so update your code accordingly if you started using it already.


