### PR TITLE
Adds context-aware feedback to default command

### DIFF
--- a/src/core-commands/default.js
+++ b/src/core-commands/default.js
@@ -1,7 +1,10 @@
 module.exports = {
-  run: ({ runtime, print }) => {
+  run: ({ parameters, runtime, print, strings, meta }) => {
+    const infoMessage = strings.isBlank(parameters.first)
+      ? `Welcome to ${print.colors.cyan(runtime.brand)} CLI version ${meta.version()}!`
+      : `Sorry, didn't recognize that command!`
     print.info(`
-  Sorry, didn't recognize that command!
+  ${infoMessage}
   Type ${print.colors.magenta(`${runtime.brand} --help`)} to view common commands.`)
   }
 }


### PR DESCRIPTION
Via @GantMan on #304 , I noticed that our current `defaultCommand` assumes when you just type `<brand>` by itself that it was a mistake. This provides a more friendly message in that case.

![image](https://user-images.githubusercontent.com/1479215/34177852-f6f1f544-e4b9-11e7-9652-b07af92403a8.png)