### PR TITLE
yarn build creates types from TS

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "gluegun": "bin/gluegun"
   },
   "main": "dist/index.js",
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "precommit": "lint-staged",
     "format": "prettier --write \"**/*.ts\" && tslint -p . --fix",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,7 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": false,
     "experimentalDecorators": true,
-    "lib": [
-      "es2016",
-      "es2016.array.include",
-      "scripthost"
-    ],
+    "lib": ["es2016", "es2016.array.include", "scripthost"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": false,
@@ -14,16 +10,14 @@
     "noUnusedLocals": true,
     "sourceMap": true,
     "outDir": "build",
+
+    // Emits types for others to consume
+    "declaration": true,
+    "declarationDir": "dist/types",
+
     "strict": false,
     "target": "es5"
   },
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "src/fixtures",
-    "*.test.ts",
-    "*.md"
-  ]
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "src/fixtures", "*.test.ts", "*.md"]
 }


### PR DESCRIPTION
I consumed gluegun 2x beta1 and though it worked as a package, my reference to the exposed types was corrupted.  This brings back types by automatic generation.

![image](https://user-images.githubusercontent.com/997157/34587934-0a6e4178-f170-11e7-9bc4-a32c526ef953.png)
