### PR TITLE
Replaces old requires with imports where possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build":
       "yarn format && yarn clean-build && yarn compile && yarn copy-templates && yarn rollup && yarn copy-cli && yarn clean-types",
     "lint": "tslint -p .",
-    "test": "ava-ts",
+    "test": "yarn build && ava-ts",
     "watch": "ava-ts --watch",
     "snapupdate": "ava-ts --update-snapshots",
     "coverage": "nyc --reporter=lcov --reporter=html --reporter=text ava-ts",
@@ -83,6 +83,7 @@
   "devDependencies": {
     "@types/cli-table2": "^0.2.1",
     "@types/node": "^8.5.1",
+    "@types/pluralize": "^0.0.28",
     "@types/ramda": "^0.25.8",
     "ava": "^0.24.0",
     "ava-ts": "^0.23.0",

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava'
 import * as sinon from 'sinon'
+import * as uniqueTempDir from 'unique-temp-dir'
 import { run as cli } from './cli'
-const uniqueTempDir = require('unique-temp-dir')
 
 sinon.stub(console, 'log')
 

--- a/src/cli/commands/new.test.ts
+++ b/src/cli/commands/new.test.ts
@@ -2,7 +2,6 @@ import test from 'ava'
 import * as sinon from 'sinon'
 import { RunContext } from '../../domain/run-context'
 import * as strings from '../../toolbox/string-tools'
-
 const command = require('./new')
 
 sinon.stub(console, 'log')

--- a/src/core-commands/default.ts
+++ b/src/core-commands/default.ts
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   run: ({ parameters, runtime, print, strings, meta }) => {
     const infoMessage = strings.isBlank(parameters.first)
       ? `Welcome to ${print.colors.cyan(runtime.brand)} CLI version ${meta.version()}!`

--- a/src/core-commands/help.ts
+++ b/src/core-commands/help.ts
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   name: 'help',
   alias: 'h',
   dashed: true,

--- a/src/core-commands/version.ts
+++ b/src/core-commands/version.ts
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   name: 'version',
   alias: 'v',
   dashed: true,

--- a/src/core-extensions/filesystem-extension.test.ts
+++ b/src/core-extensions/filesystem-extension.test.ts
@@ -3,8 +3,7 @@ import * as os from 'os'
 import * as path from 'path'
 import { split } from 'ramda'
 import { RunContext } from '../domain/run-context'
-
-const createExtension = require('./filesystem-extension')
+import createExtension from './filesystem-extension'
 
 test('has the proper interface', t => {
   const context = new RunContext()

--- a/src/core-extensions/filesystem-extension.ts
+++ b/src/core-extensions/filesystem-extension.ts
@@ -2,13 +2,14 @@ import * as jetpack from 'fs-jetpack'
 import * as os from 'os'
 import * as path from 'path'
 import { subdirectories } from '../toolbox/filesystem-tools'
+import { RunContext } from '../domain/run-context'
 
 /**
  * Extensions to filesystem.  Brought to you by fs-jetpack.
  *
  * @param  {RunContext} context The running context.
  */
-function attach(context) {
+export default function attach(context: RunContext) {
   const extension = jetpack // jetpack
   extension.eol = os.EOL // end of line marker
   extension.separator = path.sep // path separator
@@ -16,5 +17,3 @@ function attach(context) {
 
   context.filesystem = extension
 }
-
-module.exports = attach

--- a/src/core-extensions/http-extension.test.ts
+++ b/src/core-extensions/http-extension.test.ts
@@ -1,8 +1,7 @@
 import test from 'ava'
 import * as http from 'http'
 import { RunContext } from '../domain/run-context'
-
-const createExtension = require('./http-extension')
+import createExtension from './http-extension'
 
 const context = new RunContext()
 createExtension(context)

--- a/src/core-extensions/http-extension.ts
+++ b/src/core-extensions/http-extension.ts
@@ -1,12 +1,11 @@
 import { create } from 'apisauce'
+import { RunContext } from '../domain/run-context'
 
 /**
  * An extension to talk to ye olde internet.
  *
  * @param  {RunContext} context The running context.
  */
-function attach(context) {
+export default function attach(context: RunContext) {
   context.http = { create }
 }
-
-module.exports = attach

--- a/src/core-extensions/meta-extension.ts
+++ b/src/core-extensions/meta-extension.ts
@@ -1,16 +1,15 @@
 import { commandInfo, getVersion } from '../toolbox/meta-tools'
+import { RunContext } from '../domain/run-context'
 
 /**
  * Extension that lets you learn more about the currently running CLI.
  *
  * @param  {RunContext} context The running context.
  */
-function attach(context) {
+export default function attach(context: RunContext) {
   context.meta = {
     version: () => getVersion(context),
     commandInfo: () => commandInfo(context),
   }
   context.version = context.meta.version // easier access to version
 }
-
-module.exports = attach

--- a/src/core-extensions/patching-extension.test.ts
+++ b/src/core-extensions/patching-extension.test.ts
@@ -1,11 +1,8 @@
 import test from 'ava'
 import * as jetpack from 'fs-jetpack'
+import * as tempWrite from 'temp-write'
 import { RunContext } from '../domain/run-context'
-
-const create = require('./patching-extension')
-const tempWrite = require('temp-write')
-
-// const { startsWith } = require('ramdasauce')
+import create from './patching-extension'
 
 const context = new RunContext()
 create(context)

--- a/src/core-extensions/patching-extension.ts
+++ b/src/core-extensions/patching-extension.ts
@@ -2,13 +2,14 @@ import * as jetpack from 'fs-jetpack'
 import { test } from 'ramda'
 import { isFile, isNotFile } from '../toolbox/filesystem-tools'
 import { isNotString } from '../toolbox/string-tools'
+import { RunContext } from '../domain/run-context'
 
 /**
  * Builds the patching feature.
  *
  * @param  {RunContext} context The running context.
  */
-function attach(context) {
+export default function attach(context: RunContext) {
   /**
    * Identifies if something exists in a file. Async.
    *
@@ -163,5 +164,3 @@ function attach(context) {
 
   context.patching = { update, append, prepend, replace, patch, exists }
 }
-
-module.exports = attach

--- a/src/core-extensions/print-extension.test.ts
+++ b/src/core-extensions/print-extension.test.ts
@@ -1,7 +1,8 @@
 import test from 'ava'
-const printExtension = require('./print-extension')
+import { RunContext } from '../domain/run-context'
+import printExtension from './print-extension'
 
-const context: any = {}
+const context = new RunContext()
 printExtension(context)
 
 const { print } = context

--- a/src/core-extensions/print-extension.ts
+++ b/src/core-extensions/print-extension.ts
@@ -1,13 +1,12 @@
 import * as print from '../toolbox/print-tools'
+import { RunContext } from '../domain/run-context'
 
 /**
  * Extensions to print to the console.
  *
  * @param  {RunContext} context The running context.
  */
-function attach(context) {
+export default function attach(context: RunContext) {
   // attach the feature set
   context.print = print
 }
-
-module.exports = attach

--- a/src/core-extensions/prompt-extension.test.ts
+++ b/src/core-extensions/prompt-extension.test.ts
@@ -1,7 +1,6 @@
 import test from 'ava'
 import { RunContext } from '../domain/run-context'
-
-const createExtension = require('./prompt-extension')
+import createExtension from './prompt-extension'
 
 test('has the proper interface', t => {
   const context = new RunContext()

--- a/src/core-extensions/prompt-extension.ts
+++ b/src/core-extensions/prompt-extension.ts
@@ -1,11 +1,12 @@
 import * as Enquirer from 'enquirer'
+import { RunContext } from '../domain/run-context'
 
 /**
  * Provides user input prompts via enquirer.js.
  *
  * @param  {RunContext} context The running context.
  */
-function attach(context) {
+export default function attach(context: RunContext) {
   const enquirer = new Enquirer()
   enquirer.register('list', require('prompt-list'))
   enquirer.register('rawlist', require('prompt-rawlist'))
@@ -37,5 +38,3 @@ function attach(context) {
 
   context.prompt = enquirer
 }
-
-module.exports = attach

--- a/src/core-extensions/semver-extension.ts
+++ b/src/core-extensions/semver-extension.ts
@@ -1,12 +1,11 @@
 import * as semver from 'semver'
+import { RunContext } from '../domain/run-context'
 
 /**
  * Extensions to access semver and helpers
  *
  * @param  {RunContext} context The running context.
  */
-function attach(context) {
+export default function attach(context: RunContext) {
   context.semver = semver
 }
-
-module.exports = attach

--- a/src/core-extensions/strings-extension.test.ts
+++ b/src/core-extensions/strings-extension.test.ts
@@ -1,7 +1,6 @@
 import test from 'ava'
 import { RunContext } from '../domain/run-context'
-
-const createExtension = require('./strings-extension')
+import createExtension from './strings-extension'
 
 test('has the proper interface', t => {
   const context = new RunContext()

--- a/src/core-extensions/strings-extension.ts
+++ b/src/core-extensions/strings-extension.ts
@@ -1,12 +1,11 @@
 import * as stringTools from '../toolbox/string-tools'
+import { RunContext } from '../domain/run-context'
 
 /**
  * Attaches some string helpers for convenience.
  *
  * @param  {RunContext} context The running context.
  */
-function attach(context) {
+export default function attach(context: RunContext) {
   context.strings = stringTools
 }
-
-module.exports = attach

--- a/src/core-extensions/system-extension.test.ts
+++ b/src/core-extensions/system-extension.test.ts
@@ -1,7 +1,6 @@
 import test from 'ava'
 import { RunContext } from '../domain/run-context'
-
-const create = require('./system-extension')
+import create from './system-extension'
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
 

--- a/src/core-extensions/system-extension.ts
+++ b/src/core-extensions/system-extension.ts
@@ -11,7 +11,7 @@ import { RunContext } from '../domain/run-context'
  *
  * @param  {RunContext} context The running context.
  */
-function attach(context: RunContext) {
+export default function attach(context: RunContext) {
   /**
    * Executes a commandline program asynchronously.
    *
@@ -108,5 +108,3 @@ function attach(context: RunContext) {
 
   context.system = { exec, run, spawn, which, startTimer }
 }
-
-module.exports = attach

--- a/src/core-extensions/template-extension.ts
+++ b/src/core-extensions/template-extension.ts
@@ -4,13 +4,14 @@ import { forEach, keys, replace } from 'ramda'
 import { Options } from '../domain/options'
 import { isFile } from '../toolbox/filesystem-tools'
 import * as stringTools from '../toolbox/string-tools'
+import { RunContext } from '../domain/run-context'
 
 /**
  * Builds the code generation feature.
  *
  * @param  {RunContext} context The running context.
  */
-function attach(context) {
+export default function attach(context: RunContext) {
   const { plugin } = context
 
   /**
@@ -70,5 +71,3 @@ function attach(context) {
 
   context.template = { generate }
 }
-
-module.exports = attach

--- a/src/domain/builder.ts
+++ b/src/domain/builder.ts
@@ -1,4 +1,7 @@
 import { Runtime } from '../runtime/runtime'
+import coreCommandHelp from '../core-commands/help'
+import coreCommandDefault from '../core-commands/default'
+import coreCommandVersion from '../core-commands/version'
 
 /**
  * Provides a cleaner way to build a runtime.
@@ -65,7 +68,7 @@ export class Builder {
    * @return {Builder}         self.
    */
   public help(command?: any) {
-    command = command || require(`../core-commands/help`)
+    command = command || coreCommandHelp
     if (typeof command === 'function') {
       command = { name: 'help', alias: ['h'], dashed: true, run: command }
     }
@@ -78,7 +81,7 @@ export class Builder {
    * @return {Builder}         self.
    */
   public version(command?: any) {
-    command = command || require(`../core-commands/version`)
+    command = command || coreCommandVersion
     if (typeof command === 'function') {
       command = { name: 'version', alias: ['v'], dashed: true, run: command }
     }
@@ -91,7 +94,7 @@ export class Builder {
    * @return {Builder}         self.
    */
   public defaultCommand(command?: any) {
-    command = command || require(`../core-commands/default`)
+    command = command || coreCommandDefault
     if (typeof command === 'function') {
       command = { run: command }
     }

--- a/src/domain/run-context.ts
+++ b/src/domain/run-context.ts
@@ -22,7 +22,7 @@ export interface GluegunRunContext {
   // known properties
   result?: any
   error?: any
-  config: object
+  config?: object
   parameters?: RunContextParameters
   plugin?: Plugin
   command?: Command
@@ -38,7 +38,7 @@ export class RunContext implements GluegunRunContext {
   // known properties
   public result?: any
   public error?: any
-  public config: object
+  public config?: object
   public parameters?: RunContextParameters
   public plugin?: Plugin
   public command?: Command

--- a/src/fixtures/good-plugins/threepack/commands/three.js
+++ b/src/fixtures/good-plugins/threepack/commands/three.js
@@ -1,7 +1,7 @@
-const R = require('ramda')
+const { range } = require('ramda')
 
 async function three () {
-  return R.range(1, 4)
+  return range(1, 4)
 }
 
 module.exports = { name: 'three', run: three }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,7 +12,7 @@ test('create', t => {
 })
 
 test('print', t => {
-  t.is(typeof exported.printCommands, 'function')
+  t.is(typeof exported.print.printCommands, 'function')
   t.is(typeof exported.print.info, 'function')
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,3 @@
-// --- Hackasaurus Rex --------------------------------------------------------
-//
-// https://github.com/patrick-steele-idem/app-module-path-node
-// https://gist.github.com/branneman/8048520
-//
-// This adds the node_modules for `gluegun` to the "search path".
-//
-// So, wherever folks have their scripts (plugins or their apps), they will be
-// given a chance to resolve dependencies back up to gluegun's node_modules.
-//
-// I may be going to hell for this, but I'm taking you bastards with me.
-// ----------------------------------------------------------------------------
-
 // first, do a sniff test to ensure our dependencies are met
 const sniff = require('../sniff')
 
@@ -20,40 +7,39 @@ if (!sniff.isNewEnough) {
   process.exit(1)
 }
 
-// bring in a few extensions to make available for stand-alone purposes
-const attachFilesystemExtension = require('./core-extensions/filesystem-extension')
-const attachSemverExtension = require('./core-extensions/semver-extension')
-const attachSystemExtension = require('./core-extensions/system-extension')
-const attachPromptExtension = require('./core-extensions/prompt-extension')
-const attachHttpExtension = require('./core-extensions/http-extension')
-const attachTemplateExtension = require('./core-extensions/template-extension')
-const attachPatchingExtension = require('./core-extensions/patching-extension')
-
-// bring in some context
-import { build, Builder } from './domain/builder'
-import * as print from './toolbox/print-tools'
-import * as strings from './toolbox/string-tools'
-
 // we want to see real exceptions with backtraces and stuff
 process.removeAllListeners('unhandledRejection')
 process.on('unhandledRejection', up => {
   throw up
 })
 
+// bring in a few extensions to make available for stand-alone purposes
+import attachStringsExtension from './core-extensions/strings-extension'
+import attachPrintExtension from './core-extensions/print-extension'
+import attachFilesystemExtension from './core-extensions/filesystem-extension'
+import attachSemverExtension from './core-extensions/semver-extension'
+import attachSystemExtension from './core-extensions/system-extension'
+import attachPromptExtension from './core-extensions/prompt-extension'
+import attachHttpExtension from './core-extensions/http-extension'
+import attachTemplateExtension from './core-extensions/template-extension'
+import attachPatchingExtension from './core-extensions/patching-extension'
+
+// export the `build` command
+export { build } from './domain/builder'
+
+// export the GluegunRunContext interface
+export { GluegunRunContext } from './domain/run-context'
+
+// this adds the node_modules path to the "search path"
+// it's hacky, but it works well!
 require('app-module-path').addPath(`${__dirname}/../node_modules`)
 require('app-module-path').addPath(process.cwd())
-// ----------------------------------------------------------------------------
 
-const { printCommands, printHelp } = print
+// build a temporary context to hang things on
+const context: any = {}
 
-const context: { build: () => Builder; [key: string]: any } = {
-  build,
-  strings,
-  print,
-  printCommands,
-  printHelp,
-}
-
+attachStringsExtension(context)
+attachPrintExtension(context)
 attachFilesystemExtension(context)
 attachSemverExtension(context)
 attachSystemExtension(context)
@@ -62,28 +48,13 @@ attachHttpExtension(context)
 attachTemplateExtension(context)
 attachPatchingExtension(context)
 
-const filesystem = context.filesystem
-const semver = context.semver
-const system = context.system
-const prompt = context.prompt
-const http = context.http
-const template = context.template
-const patching = context.patching
-
-import { GluegunRunContext } from './domain/run-context'
-
-export {
-  GluegunRunContext,
-  build,
-  strings,
-  print,
-  printCommands,
-  printHelp,
-  filesystem,
-  semver,
-  system,
-  prompt,
-  http,
-  template,
-  patching,
-}
+export const filesystem = context.filesystem
+export const semver = context.semver
+export const system = context.system
+export const prompt = context.prompt
+export const http = context.http
+export const template = context.template
+export const patching = context.patching
+export const print = context.print
+export const generate = context.generate
+export const strings = context.strings

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -1,17 +1,37 @@
+// helpers
+import { resolve } from 'path'
+import { dissoc } from 'ramda'
+
+// domains
 import { Command } from '../domain/command'
 import { Extension } from '../domain/extension'
 import { Plugin } from '../domain/plugin'
 import { RunContext } from '../domain/run-context'
+import { Options } from '../domain/options'
+
+// loaders
 import { loadCommandFromPreload } from '../loaders/command-loader'
 import { loadConfig } from '../loaders/config-loader'
 import { loadPluginFromDirectory } from '../loaders/plugin-loader'
+
+// tools
 import { isDirectory, subdirectories } from '../toolbox/filesystem-tools'
 import { isBlank } from '../toolbox/string-tools'
+
+// the special run function
 import { run } from './run'
 
-import { resolve } from 'path'
-import { dissoc } from 'ramda'
-import { Options } from '../domain/options'
+// core extensions
+import metaExtensionAttach from '../core-extensions/meta-extension'
+import templateExtensionAttach from '../core-extensions/template-extension'
+import printExtensionAttach from '../core-extensions/print-extension'
+import filesystemExtensionAttach from '../core-extensions/filesystem-extension'
+import semverExtensionAttach from '../core-extensions/semver-extension'
+import systemExtensionAttach from '../core-extensions/system-extension'
+import promptExtensionAttach from '../core-extensions/prompt-extension'
+import httpExtensionAttach from '../core-extensions/http-extension'
+import stringsExtensionAttach from '../core-extensions/strings-extension'
+import patchingExtensionAttach from '../core-extensions/patching-extension'
 
 /**
  * Loads plugins, extensions, and invokes the intended command.
@@ -54,16 +74,16 @@ export class Runtime {
    * for extending the core as 3rd party extensions do.
    */
   public addCoreExtensions(): void {
-    this.addExtension('meta', require('../core-extensions/meta-extension'))
-    this.addExtension('strings', require('../core-extensions/template-extension'))
-    this.addExtension('print', require('../core-extensions/print-extension'))
-    this.addExtension('template', require('../core-extensions/filesystem-extension'))
-    this.addExtension('filesystem', require('../core-extensions/semver-extension'))
-    this.addExtension('semver', require('../core-extensions/system-extension'))
-    this.addExtension('system', require('../core-extensions/prompt-extension'))
-    this.addExtension('http', require('../core-extensions/http-extension'))
-    this.addExtension('prompt', require('../core-extensions/strings-extension'))
-    this.addExtension('patching', require('../core-extensions/patching-extension'))
+    this.addExtension('meta', metaExtensionAttach)
+    this.addExtension('strings', templateExtensionAttach)
+    this.addExtension('print', printExtensionAttach)
+    this.addExtension('template', filesystemExtensionAttach)
+    this.addExtension('filesystem', semverExtensionAttach)
+    this.addExtension('semver', systemExtensionAttach)
+    this.addExtension('system', promptExtensionAttach)
+    this.addExtension('http', httpExtensionAttach)
+    this.addExtension('prompt', stringsExtensionAttach)
+    this.addExtension('patching', patchingExtensionAttach)
   }
 
   /**

--- a/src/toolbox/print-tools.test.ts
+++ b/src/toolbox/print-tools.test.ts
@@ -1,19 +1,11 @@
 import test from 'ava'
 import * as stripANSI from 'strip-ansi'
+import * as print from './print-tools'
 
 // hijack the console
 const log = console.log
-
 let spyLogger = []
 console.log = (x, y) => spyLogger.push([stripANSI(x), stripANSI(y)])
-
-// then spy on it
-// const spyLog = sinon.spy(console, 'log')
-
-// finally require the print
-const print = require('./print-tools')
-
-// test.before(() => null)
 
 test.after.always(() => {
   spyLogger = []

--- a/src/toolbox/print-tools.ts
+++ b/src/toolbox/print-tools.ts
@@ -1,7 +1,10 @@
 import * as CLITable from 'cli-table2'
-import * as colors from 'colors'
+import * as colorsModule from 'colors'
 import { commandInfo } from './meta-tools'
-const ora = require('ora')
+import { RunContext } from '../domain/run-context'
+import * as ora from 'ora'
+
+export const colors = colorsModule
 
 const CLI_TABLE_COMPACT = {
   top: '',
@@ -44,21 +47,21 @@ colors.setTheme({
 /**
  * Print a blank line.
  */
-function newline() {
+export function newline() {
   console.log('')
 }
 
 /**
  * Prints a divider line
  */
-function divider() {
+export function divider() {
   console.log(colors.line('---------------------------------------------------------------'))
 }
 
 /**
  * Returns an array of the column widths.
  */
-function findWidths(tableArray) {
+export function findWidths(tableArray) {
   return [tableArray.options.head, ...tableArray].reduce(
     (colWidths, row) => row.map((str, i) => Math.max(`${str}`.length + 1, colWidths[i] || 1)),
     [],
@@ -68,7 +71,7 @@ function findWidths(tableArray) {
 /**
  * Returns an array of column headers based on column widths.
  */
-function columnHeaderDivider(tableArray) {
+export function columnHeaderDivider(tableArray) {
   return findWidths(tableArray).map(w => Array(w).join('-'))
 }
 
@@ -78,7 +81,7 @@ function columnHeaderDivider(tableArray) {
  *
  * @param {{}} object The object to turn into a table.
  */
-function table(data: string[][], options: any = {}) {
+export function table(data: string[][], options: any = {}) {
   let t
   switch (options.format) {
     case 'markdown':
@@ -111,7 +114,7 @@ function table(data: string[][], options: any = {}) {
  *
  * @param {string} message The message to write.
  */
-function fancy(message: string) {
+export function fancy(message: string) {
   console.log(message)
 }
 
@@ -122,7 +125,7 @@ function fancy(message: string) {
  *
  * @param {string} message The message to show.
  */
-function info(message: string) {
+export function info(message: string) {
   console.log(colors.info(message))
 }
 
@@ -133,7 +136,7 @@ function info(message: string) {
  *
  * @param {string} message The message to show.
  */
-function error(message: string) {
+export function error(message: string) {
   console.log(colors.error(message))
 }
 
@@ -144,7 +147,7 @@ function error(message: string) {
  *
  * @param {string} message The message to show.
  */
-function warning(message: string) {
+export function warning(message: string) {
   console.log(colors.warning(message))
 }
 
@@ -155,7 +158,7 @@ function warning(message: string) {
  *
  * @param {string} message The message to show.
  */
-function debug(message: string, title: string = 'DEBUG') {
+export function debug(message: string, title: string = 'DEBUG') {
   const topLine = `vvv -----[ ${title} ]----- vvv`
   const botLine = `^^^ -----[ ${title} ]----- ^^^`
 
@@ -171,7 +174,7 @@ function debug(message: string, title: string = 'DEBUG') {
  *
  * @param {string} message The message to show.
  */
-function success(message: string) {
+export function success(message: string) {
   console.log(colors.success(message))
 }
 
@@ -181,8 +184,8 @@ function success(message: string) {
  * @param {string|Object} config The text for the spinner or an ora configuration object.
  * @returns The spinner.
  */
-function spin(config: string | object) {
-  return ora(config).start()
+export function spin(config?: string | object) {
+  return ora(config || '').start()
 }
 
 /**
@@ -191,7 +194,7 @@ function spin(config: string | object) {
  * @param {RunContext} context     The context that was used
  * @param {string[]} commandRoot   Optional, only show commands with this root
  */
-function printCommands(context, commandRoot?: string[]) {
+export function printCommands(context: RunContext, commandRoot?: string[]) {
   let printPlugins = []
   if (context.plugin === context.defaultPlugin) {
     // print for all plugins
@@ -207,29 +210,11 @@ function printCommands(context, commandRoot?: string[]) {
   table(data) // the data
 }
 
-function printHelp(context) {
+export function printHelp(context) {
   const { runtime: { brand } } = context
   info(`${brand} version ${context.meta.version()}`)
   printCommands(context)
 }
 
-const checkmark = colors.success('✔︎')
-const xmark = colors.error('ⅹ')
-
-export {
-  info,
-  warning,
-  success,
-  error,
-  debug,
-  fancy,
-  divider,
-  newline,
-  table,
-  spin,
-  colors,
-  printCommands,
-  printHelp,
-  checkmark,
-  xmark,
-}
+export const checkmark = colors.success('✔︎')
+export const xmark = colors.error('ⅹ')

--- a/src/toolbox/string-tools.ts
+++ b/src/toolbox/string-tools.ts
@@ -1,31 +1,47 @@
-import * as camelCase from 'lodash.camelcase'
-import * as kebabCase from 'lodash.kebabcase'
-import * as lowerCase from 'lodash.lowercase'
-import * as lowerFirst from 'lodash.lowerfirst'
-import * as pad from 'lodash.pad'
-import * as padEnd from 'lodash.padend'
-import * as padStart from 'lodash.padstart'
-import * as repeat from 'lodash.repeat'
-import * as snakeCase from 'lodash.snakecase'
-import * as startCase from 'lodash.startcase'
-import * as trim from 'lodash.trim'
-import * as trimEnd from 'lodash.trimend'
-import * as trimStart from 'lodash.trimstart'
-import * as upperCase from 'lodash.uppercase'
-import * as upperFirst from 'lodash.upperfirst'
-import * as pluralize from 'pluralize'
 import { is, isEmpty, pipe } from 'ramda'
 
-const {
-  plural,
-  singular,
-  addPluralRule,
-  addSingularRule,
-  addIrregularRule,
-  addUncountableRule,
-  isPlural,
-  isSingular,
-} = pluralize
+import * as lodashCamelCase from 'lodash.camelcase'
+import * as lodashKebabCase from 'lodash.kebabcase'
+import * as lodashLowerCase from 'lodash.lowercase'
+import * as lodashLowerFirst from 'lodash.lowerfirst'
+import * as lodashPad from 'lodash.pad'
+import * as lodashPadEnd from 'lodash.padend'
+import * as lodashPadStart from 'lodash.padstart'
+import * as lodashRepeat from 'lodash.repeat'
+import * as lodashSnakeCase from 'lodash.snakecase'
+import * as lodashStartCase from 'lodash.startcase'
+import * as lodashTrim from 'lodash.trim'
+import * as lodashTrimEnd from 'lodash.trimend'
+import * as lodashTrimStart from 'lodash.trimstart'
+import * as lodashUpperCase from 'lodash.uppercase'
+import * as lodashUpperFirst from 'lodash.upperfirst'
+import * as pluralizeModule from 'pluralize'
+
+export const camelCase = lodashCamelCase
+export const kebabCase = lodashKebabCase
+export const lowerCase = lodashLowerCase
+export const lowerFirst = lodashLowerFirst
+export const pad = lodashPad
+export const padEnd = lodashPadEnd
+export const padStart = lodashPadStart
+export const repeat = lodashRepeat
+export const snakeCase = lodashSnakeCase
+export const startCase = lodashStartCase
+export const trim = lodashTrim
+export const trimEnd = lodashTrimEnd
+export const trimStart = lodashTrimStart
+export const upperCase = lodashUpperCase
+export const upperFirst = lodashUpperFirst
+
+export const pluralize = pluralizeModule
+export const plural = pluralize.plural
+export const singular = pluralize.singular
+export const addPluralRule = pluralize.addPluralRule
+export const addSingularRule = pluralize.addSingularRule
+export const addIrregularRule = pluralize.addIrregularRule
+export const addUncountableRule = pluralize.addUncountableRule
+export const isPlural = pluralize.isPlural
+export const isSingular = pluralize.isSingular
 
 /**
  * Is this not a string?
@@ -33,7 +49,7 @@ const {
  * @param  {any}     value The value to check
  * @return {boolean}       True if it is not a string, otherwise false
  */
-const isNotString = value => {
+export const isNotString = value => {
   return !is(String, value)
 }
 
@@ -43,7 +59,7 @@ const isNotString = value => {
  * @param   {any}     value The value to check.
  * @returns {boolean}       True if it was, otherwise false.
  */
-const isBlank = (value: any) => {
+export const isBlank = (value: any) => {
   return isNotString(value) || isEmpty(trim(value))
 }
 
@@ -53,7 +69,7 @@ const isBlank = (value: any) => {
  * @param {any} value
  * @returns     the value.
  */
-function identity(value) {
+export function identity(value) {
   return value
 }
 
@@ -63,37 +79,6 @@ function identity(value) {
  * @param {string} value The string to convert
  * @returns {string}
  */
-function pascalCase(value) {
+export function pascalCase(value) {
   return pipe(camelCase, upperFirst)(value)
-}
-
-export {
-  identity,
-  isBlank,
-  isNotString,
-  camelCase,
-  kebabCase,
-  snakeCase,
-  upperCase,
-  lowerCase,
-  startCase,
-  upperFirst,
-  lowerFirst,
-  pascalCase,
-  pad,
-  padStart,
-  padEnd,
-  trim,
-  trimStart,
-  trimEnd,
-  repeat,
-  pluralize,
-  plural,
-  singular,
-  addPluralRule,
-  addSingularRule,
-  addIrregularRule,
-  addUncountableRule,
-  isPlural,
-  isSingular,
 }


### PR DESCRIPTION
This PR replaces a few `require` statements with `import` instead, and exports in a more friendly way. Fixes #310, #311, #312.

## Remaining requires

I have a few remaining requires. These are either in test fixtures (whatevs -- because node doesn't like `import` yet) or requiring dynamic files, like extensions or commands.

## Core extensions and commands

Note that the core extensions and commands are `import`ed. This is because they are known ahead-of-time.

*Question: will this be confusing to people looking at our source code?* They have to write their extensions and commands as commonJS modules, but we write them as es6 modules.

Example:

```js
// our core-commands/new.ts
export default {
  run: (...) => {
    // ...
  },
}

// their commands/new.js
module.exports = {
  run: (...) => {
    // ...
  }
}
```

I _can_ keep our internal commands and extensions as commonJS modules. No real preference. Input requested.
