### PR TITLE
Updates types to properly support Solidarity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -432,11 +432,19 @@
       }
     },
     "apisauce": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/apisauce/-/apisauce-0.14.1.tgz",
-      "integrity": "sha512-rcv1FZdnKBg6heJ/I5z0FbcBL7WQPiF84ZGG9R7B1rDkGlRD7fkKn6XmU0Hky0SxanmQnmA4+h2r3L1BeWaGsw==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/apisauce/-/apisauce-0.14.2.tgz",
+      "integrity": "sha512-S7YVzT9FX3f94u3kdPh/vY28OqTLSPUT1IyQ/3I6uz22jHIKaq2xt/F4PjQBLrWsmsD0rXdIsLULRnYbEZlyog==",
       "requires": {
-        "axios": "0.16.2"
+        "axios": "0.16.2",
+        "ramda": "0.24.1"
+      },
+      "dependencies": {
+        "ramda": {
+          "version": "0.24.1",
+          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
+          "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc="
+        }
       }
     },
     "app-module-path": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "apisauce": "^0.14.1",
+    "apisauce": "0.14.3",
     "app-module-path": "^2.2.0",
     "cli-table2": "^0.2.0",
     "colors": "^1.1.2",

--- a/src/domain/command.ts
+++ b/src/domain/command.ts
@@ -1,17 +1,27 @@
 import { RunContext } from './run-context'
 
+export interface GluegunCommand {
+  name?: string
+  description?: string
+  run: (context: RunContext) => void
+  hidden?: boolean
+  commandPath?: string[]
+  alias?: string | string[]
+  dashed?: boolean
+}
+
 /**
  * A command is user-callable function that runs stuff.
  */
-export class Command {
-  public name?: string
-  public description?: string
-  public file?: string
-  public run?: (context: RunContext) => any
-  public hidden: boolean
-  public commandPath?: string[]
-  public alias: string[]
-  public dashed: boolean
+export class Command implements GluegunCommand {
+  public name
+  public description
+  public file
+  public run
+  public hidden
+  public commandPath
+  public alias
+  public dashed
 
   constructor() {
     this.name = null

--- a/src/domain/run-context.ts
+++ b/src/domain/run-context.ts
@@ -1,4 +1,3 @@
-import { GluegunRunContext } from '../index'
 import { Runtime } from '../runtime/runtime'
 import { Command } from './command'
 import { Options } from './options'
@@ -16,35 +15,46 @@ export interface RunContextParameters {
 }
 
 export interface GluegunRunContext {
-  // our catch-all! since we can add whatever to this object
-  [key: string]: any
-
   // known properties
   result?: any
   error?: any
   config?: object
-  parameters?: RunContextParameters
+  parameters: RunContextParameters
   plugin?: Plugin
   command?: Command
   pluginName?: string
   commandName?: string
   runtime?: Runtime
+
+  // known extensions
+  filesystem?: any
+  http?: any
+  meta?: any
+  patching?: any
+  print?: any
+  prompt?: any
+  semver?: any
+  strings?: any
+  system?: any
+  template?: any
+  generate?: any
+
+  // our catch-all! since we can add whatever to this object
+  [key: string]: any
 }
 
 export class RunContext implements GluegunRunContext {
-  // our catch-all! since we can add whatever to this object
   [key: string]: any
 
-  // known properties
-  public result?: any
-  public error?: any
-  public config?: object
-  public parameters?: RunContextParameters
-  public plugin?: Plugin
-  public command?: Command
-  public pluginName?: string
-  public commandName?: string
-  public runtime?: Runtime
+  public result
+  public error
+  public config
+  public parameters
+  public plugin
+  public command
+  public pluginName
+  public commandName
+  public runtime
 
   constructor() {
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export { build } from './domain/builder'
 
 // export the GluegunRunContext interface
 export { GluegunRunContext } from './domain/run-context'
+export { GluegunCommand } from './domain/command'
 
 // this adds the node_modules path to the "search path"
 // it's hacky, but it works well!

--- a/src/runtime/run.ts
+++ b/src/runtime/run.ts
@@ -11,7 +11,7 @@ import { findCommand } from './runtime-find-command'
  * @param  {{}} extraOptions Additional options use to execute a command.
  * @return {RunContext} The RunContext object indicating what happened.
  */
-export async function run(this: Runtime, rawCommand: string | object, extraOptions = {}): Promise<RunContext> {
+export async function run(this: Runtime, rawCommand?: string | object, extraOptions = {}): Promise<RunContext> {
   // use provided rawCommand or process arguments if none given
   rawCommand = rawCommand || process.argv
 

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -43,7 +43,7 @@ export class Runtime {
   public defaults?: object
   public defaultPlugin?: Plugin
   public config?: object
-  public run?: (rawCommand: string | object, extraOptions?: object) => any
+  public run: (rawCommand?: string | object, extraOptions?: object) => any
 
   /**
    * Create and initialize an empty Runtime.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,11 +10,9 @@
     "noUnusedLocals": true,
     "sourceMap": true,
     "outDir": "build",
-
     // Emits types for others to consume
     "declaration": true,
     "declarationDir": "dist/types",
-
     "strict": false,
     "target": "es5"
   },


### PR DESCRIPTION
@GantMan was having a lot of issues with the latest version of Gluegun (2.0.0-beta.2) not properly exporting types for [Solidarity](https://github.com/infinitered/solidarity). This PR massages the types so Solidarity compiles and builds.

🤔  I now know why @skellock was exporting interfaces rather than classes 
🚂  It's likely more massaging will be in order for other CLIs, like App Machine 
🍶  This also updates [apisauce](https://github.com/infinitered/apisauce) to the latest version, because that was causing some type errors ... _we think_ 



