### PR TITLE
🧛‍♀️ Adds support for `export default` (if using TypeScript)

### DIFF
--- a/src/cli/commands/new.test.ts
+++ b/src/cli/commands/new.test.ts
@@ -2,7 +2,7 @@ import test from 'ava'
 import * as sinon from 'sinon'
 import { RunContext } from '../../domain/run-context'
 import * as strings from '../../toolbox/string-tools'
-const command = require('./new')
+import command from './new'
 
 sinon.stub(console, 'log')
 

--- a/src/cli/commands/new.ts
+++ b/src/cli/commands/new.ts
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   name: 'new',
   alias: ['n', 'create'],
   description: 'Creates a new gluegun cli',

--- a/src/cli/extensions/cli-extension.ts
+++ b/src/cli/extensions/cli-extension.ts
@@ -1,7 +1,7 @@
 import { chmodSync } from 'fs'
 import { resolve } from 'path'
 
-module.exports = context => {
+export default context => {
   context.filesystem.resolve = resolve
   context.filesystem.chmodSync = chmodSync
 }

--- a/src/core-extensions/prompt-extension.ts
+++ b/src/core-extensions/prompt-extension.ts
@@ -1,5 +1,14 @@
 import * as Enquirer from 'enquirer'
 import { RunContext } from '../domain/run-context'
+import * as promptList from 'prompt-list'
+import * as promptRawlist from 'prompt-rawlist'
+import * as promptConfirm from 'prompt-confirm'
+import * as promptExpand from 'prompt-expand'
+import * as promptCheckbox from 'prompt-checkbox'
+import * as promptRadio from 'prompt-radio'
+import * as promptPassword from 'prompt-password'
+import * as promptQuestion from 'prompt-question'
+import * as promptAutocompletion from 'prompt-autocompletion'
 
 /**
  * Provides user input prompts via enquirer.js.
@@ -8,15 +17,15 @@ import { RunContext } from '../domain/run-context'
  */
 export default function attach(context: RunContext): void {
   const enquirer = new Enquirer()
-  enquirer.register('list', require('prompt-list'))
-  enquirer.register('rawlist', require('prompt-rawlist'))
-  enquirer.register('confirm', require('prompt-confirm'))
-  enquirer.register('expand', require('prompt-expand'))
-  enquirer.register('checkbox', require('prompt-checkbox'))
-  enquirer.register('radio', require('prompt-radio'))
-  enquirer.register('password', require('prompt-password'))
-  enquirer.register('question', require('prompt-question'))
-  enquirer.register('autocomplete', require('prompt-autocompletion'))
+  enquirer.register('list', promptList)
+  enquirer.register('rawlist', promptRawlist)
+  enquirer.register('confirm', promptConfirm)
+  enquirer.register('expand', promptExpand)
+  enquirer.register('checkbox', promptCheckbox)
+  enquirer.register('radio', promptRadio)
+  enquirer.register('password', promptPassword)
+  enquirer.register('question', promptQuestion)
+  enquirer.register('autocomplete', promptAutocompletion)
 
   /**
    * A yes/no question.

--- a/src/loaders/command-loader.ts
+++ b/src/loaders/command-loader.ts
@@ -41,9 +41,12 @@ export function loadCommandFromFile(file: string, options: Options = {}): Comman
   }
 
   // require in the module -- best chance to bomb is here
-  const commandModule = loadModule(file)
+  let commandModule = loadModule(file)
 
-  // are we expecting this?
+  // if they use `export default` rather than `module.exports =`, we extract that
+  commandModule = commandModule.default || commandModule
+
+  // is it a valid commandModule?
   const valid = commandModule && typeof commandModule === 'object' && typeof commandModule.run === 'function'
 
   if (valid) {

--- a/src/loaders/extension-loader.ts
+++ b/src/loaders/extension-loader.ts
@@ -30,7 +30,10 @@ export function loadExtensionFromFile(file: string, options = {}): Extension {
   extension.name = head(split('.', jetpack.inspect(file).name))
 
   // require in the module -- best chance to bomb is here
-  const extensionModule = loadModule(file)
+  let extensionModule = loadModule(file)
+
+  // if they use `export default` rather than `module.exports =`, we extract that
+  extensionModule = extensionModule.default || extensionModule
 
   // should we try the default export?
   const valid = extensionModule && typeof extensionModule === 'function'


### PR DESCRIPTION
Per #337, this change will support using `export default` in commands and extensions ... _if_ you are using TypeScript. If you're on straight Node, it'll choke on it, saying something like "SyntaxError: Unexpected token export". This is a backwards-compatible change.

