### PR TITLE
🦅 Improvements to command path resolver

### DIFF
--- a/src/core-extensions/template-extension.test.ts
+++ b/src/core-extensions/template-extension.test.ts
@@ -9,13 +9,13 @@ const createRuntime = () => {
 }
 
 test('generates a simple file', async t => {
-  const context = await createRuntime().run('generate simple')
+  const context = await createRuntime().run('simple')
 
   t.is(context.result, 'simple file\n')
 })
 
 test('supports props', async t => {
-  const context = await createRuntime().run('generate props Greetings_and_salutations', {
+  const context = await createRuntime().run('props Greetings_and_salutations', {
     stars: 5,
   })
 
@@ -32,14 +32,14 @@ blue
 
 test('detects missing templates', async t => {
   try {
-    await createRuntime().run('generate missing')
+    await createRuntime().run('missing')
   } catch (e) {
     t.true(startsWith('template not found', e.message))
   }
 })
 
 test('supports directories', async t => {
-  const context = await createRuntime().run('generate special location')
+  const context = await createRuntime().run('special location')
 
   t.is(
     context.result,

--- a/src/domain/builder.test.ts
+++ b/src/domain/builder.test.ts
@@ -24,7 +24,7 @@ test('the gauntlet', t => {
   const runtime = builder.create()
   t.truthy(runtime)
 
-  t.is(runtime.commands.length, 25)
+  t.is(runtime.commands.length, 26)
   t.is(runtime.extensions.length, 13)
   t.is(runtime.defaultPlugin.commands.length, 6)
 

--- a/src/fixtures/good-plugins/nested/commands/implied/bar.js
+++ b/src/fixtures/good-plugins/nested/commands/implied/bar.js
@@ -1,0 +1,3 @@
+module.exports = {
+  run: () => 'implied'
+}

--- a/src/runtime/runtime-config.test.ts
+++ b/src/runtime/runtime-config.test.ts
@@ -4,7 +4,7 @@ import { Runtime } from './runtime'
 test('can read from config', async t => {
   const r = new Runtime()
   const plugin = r.addPlugin(`${__dirname}/../fixtures/good-plugins/args`)
-  const context = await r.run('args config')
+  const context = await r.run('config')
 
   t.truthy(plugin.defaults)
   t.is(plugin.defaults.color, 'blue')
@@ -15,7 +15,7 @@ test('project config trumps plugin config', async t => {
   const r = new Runtime()
   r.defaults = { args: { color: 'red' } }
   const plugin = r.addPlugin(`${__dirname}/../fixtures/good-plugins/args`)
-  const context = await r.run('args config')
+  const context = await r.run('config')
 
   t.truthy(plugin.defaults)
   t.is(plugin.defaults.color, 'blue')

--- a/src/runtime/runtime-find-command.ts
+++ b/src/runtime/runtime-find-command.ts
@@ -21,42 +21,43 @@ export function findCommand(runtime: Runtime, parameters: RunContextParameters) 
 
   // the part of the commandPath that doesn't match a command
   // in the above example, it will end up being [ '2015' ]
-  let commandPathRest = commandPath.slice()
-  let rest = commandPathRest
+  let tempPathRest = commandPath
+  let commandPathRest = tempPathRest
 
   // the resolved command will live here
   // start by setting it to the default command, in case we don't find one
   let targetCommand: Command = runtime.defaultCommand
 
+  // store the resolved path as we go
+  let resolvedPath: string[] = []
+
   // we loop through each segment of the commandPath, looking for aliases among
   // parent commands, and expand those.
-  commandPath.reduce((prevPath: string[], currName: string) => {
+  commandPath.forEach((currName: string) => {
     // cut another piece off the front of the commandPath
-    commandPathRest = commandPathRest.slice(1)
+    tempPathRest = tempPathRest.slice(1)
 
     // find a command that fits the previous path + currentName, which can be an alias
     let segmentCommand = runtime.commands
       .sort(sortCommands)
-      .find(command => equals(command.commandPath.slice(0, -1), prevPath) && command.matchesAlias(currName))
+      .find(command => equals(command.commandPath.slice(0, -1), resolvedPath) && command.matchesAlias(currName))
 
     if (segmentCommand) {
       // found another candidate as the "endpoint" command
       targetCommand = segmentCommand
 
-      // since we found a command, the "rest" gets updated to the commandPathRest
-      rest = commandPathRest
+      // since we found a command, the "commandPathRest" gets updated to the tempPathRest
+      commandPathRest = tempPathRest
 
-      // add the current command to the prevPath
-      prevPath = prevPath.concat([segmentCommand.name])
+      // add the current command to the resolvedPath
+      resolvedPath = resolvedPath.concat([segmentCommand.name])
     } else {
       // no command found, let's add the segment as-is to the command path
-      prevPath = prevPath.concat([currName])
+      resolvedPath = resolvedPath.concat([currName])
     }
-
-    return prevPath
   }, [])
 
-  return { command: targetCommand, array: rest }
+  return { command: targetCommand, array: commandPathRest }
 }
 
 // sorts shortest to longest commandPaths, so we always check the shortest ones first

--- a/src/runtime/runtime-find-command.ts
+++ b/src/runtime/runtime-find-command.ts
@@ -1,4 +1,4 @@
-import { equals, last } from 'ramda'
+import { equals } from 'ramda'
 
 import { Command } from '../domain/command'
 import { Runtime } from './runtime'
@@ -21,14 +21,18 @@ export function findCommand(runtime: Runtime, parameters: RunContextParameters) 
 
   // the part of the commandPath that doesn't match a command
   // in the above example, it will end up being [ '2015' ]
-  const rest = commandPath.slice()
+  let commandPathRest = commandPath.slice()
+  let rest = commandPathRest
+
+  // the resolved command will live here
+  // start by setting it to the default command, in case we don't find one
+  let targetCommand: Command = runtime.defaultCommand
 
   // we loop through each segment of the commandPath, looking for aliases among
   // parent commands, and expand those.
-  const foundCommands = commandPath.reduce((prevCommands: Command[], currName: string) => {
-    // what is the path for the last known command?
-    const lastCommand = last(prevCommands)
-    const prevPath = lastCommand ? lastCommand.commandPath : []
+  commandPath.reduce((prevPath: string[], currName: string) => {
+    // cut another piece off the front of the commandPath
+    commandPathRest = commandPathRest.slice(1)
 
     // find a command that fits the previous path + currentName, which can be an alias
     let segmentCommand = runtime.commands
@@ -36,19 +40,21 @@ export function findCommand(runtime: Runtime, parameters: RunContextParameters) 
       .find(command => equals(command.commandPath.slice(0, -1), prevPath) && command.matchesAlias(currName))
 
     if (segmentCommand) {
-      // remove another segment from the commandPath
-      rest.shift()
-      // add the new command to the path
-      return prevCommands.concat([segmentCommand])
-    } else {
-      // didn't find a command that fit this description
-      return prevCommands
-    }
-  }, [])
+      // found another candidate as the "endpoint" command
+      targetCommand = segmentCommand
 
-  // the last command is the one we run
-  // if no targetCommand found, use the default (if set)
-  let targetCommand = last(foundCommands) || runtime.defaultCommand
+      // since we found a command, the "rest" gets updated to the commandPathRest
+      rest = commandPathRest
+
+      // add the current command to the prevPath
+      prevPath = prevPath.concat([segmentCommand.name])
+    } else {
+      // no command found, let's add the segment as-is to the command path
+      prevPath = prevPath.concat([currName])
+    }
+
+    return prevPath
+  }, [])
 
   return { command: targetCommand, array: rest }
 }

--- a/src/runtime/runtime-parameters.test.ts
+++ b/src/runtime/runtime-parameters.test.ts
@@ -46,3 +46,15 @@ test('can pass arguments with mixed options', async t => {
   t.is(parameters.options.n, 1)
   t.is(parameters.options.chocolate, 'true')
 })
+
+test('properly infers the heirarchy from folder structure', async t => {
+  const r = new Runtime()
+  r.addPlugin(`${__dirname}/../fixtures/good-plugins/nested`)
+  const { command, parameters } = await r.run('implied bar thing --foo=1 --force')
+
+  t.deepEqual(command.commandPath, ['implied', 'bar'])
+  t.is(parameters.string, 'thing')
+  t.is(parameters.command, 'bar')
+  t.is(parameters.options.foo, 1)
+  t.true(parameters.options.force)
+})

--- a/src/runtime/runtime-run-bad.test.ts
+++ b/src/runtime/runtime-run-bad.test.ts
@@ -13,7 +13,7 @@ test('is fatally wounded by exceptions', async t => {
 
   // for some reason, t.throws doesn't work on this one ...
   try {
-    await r.run('throws throw')
+    await r.run('throw')
   } catch (e) {
     t.is(e.message, `thrown an error!`)
   }

--- a/src/runtime/runtime-run-good.test.ts
+++ b/src/runtime/runtime-run-good.test.ts
@@ -4,7 +4,7 @@ import { Runtime } from './runtime'
 test('runs a command', async t => {
   const r = new Runtime()
   r.addPlugin(`${__dirname}/../fixtures/good-plugins/threepack`)
-  const context = await r.run('3pack three')
+  const context = await r.run('three')
 
   t.deepEqual(context.result, [1, 2, 3])
 })
@@ -12,7 +12,7 @@ test('runs a command', async t => {
 test('runs an aliased command', async t => {
   const r = new Runtime()
   r.addPlugin(`${__dirname}/../fixtures/good-plugins/threepack`)
-  const context = await r.run('3pack o')
+  const context = await r.run('o')
 
   t.is(context.result, 1)
 })
@@ -30,7 +30,7 @@ test('runs a nested command', async t => {
 test('runs a command with no name prop', async t => {
   const r = new Runtime()
   r.addPlugin(`${__dirname}/../fixtures/good-plugins/missing-name`)
-  const context = await r.run('missing-name foo')
+  const context = await r.run('foo')
   t.truthy(context.command)
   t.is(context.command.name, 'foo')
 })

--- a/src/runtime/runtime-src.test.ts
+++ b/src/runtime/runtime-src.test.ts
@@ -6,7 +6,7 @@ test('runs a command explicitly', async t => {
   t.falsy(r.defaultPlugin)
   r.addDefaultPlugin(`${__dirname}/../fixtures/good-plugins/threepack`)
   t.truthy(r.defaultPlugin)
-  const context = await r.run('3pack three')
+  const context = await r.run('three')
 
   t.truthy(context.plugin)
   t.truthy(context.command)
@@ -20,7 +20,7 @@ test('runs a command via passed in args', async t => {
   t.falsy(r.defaultPlugin)
   r.addDefaultPlugin(`${__dirname}/../fixtures/good-plugins/threepack`)
   t.truthy(r.defaultPlugin)
-  const context = await r.run('3pack three')
+  const context = await r.run('three')
   t.truthy(context.plugin)
   t.truthy(context.command)
   t.is(context.plugin.name, '3pack')


### PR DESCRIPTION
The command resolver (`findCommand`) is simpler and better, and the result is the following two improvements to command resolution:

###  Plugins no longer automatically namespace, which allows for adding commands at the root level via plugin

Let's say you have a plugin that adds a few commands, called `movie-imdb`. It adds `movie imdb list` and `movie imdb search` commands.

In the past, you'd structure your plugin like this:

```
movie-imdb
  src
    commands
      list.js
      search.js
```

Now, this would result in the commands being `movie list` and `movie search`. To regain the `imdb` namespace, just move your commands into an intervening folder:

```
movie-imdb
  src
    commands
      imdb
        list.js
        search.js
```

This allows for a greater amount of freedom in how plugins affect your CLI, in that they can add root-level commands.

###  Nested commands can be resolved specifically by their folder structure, per #331.

In implementing the above change, I was able to also resolve issue #331, which now uses folder structure to resolve commands rather than requiring a command at every segment.

For example, in the past, to do `movie imdb tvshows search`, you'd have to do something like this:

```
movie
  src
    commands
      imdb
        imdb.js
        tvshows
          tvshows.js
          search.js
```

Now, you don't have to have the intervening commands:

```
movie
  src
    commands
      imdb
        tvshows
          search.js
```

`movie imdb tvshows search` will run the proper command now.