### PR TITLE
👷 Refactors Builder to accept options in any order

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -2,13 +2,12 @@ With the gluegun API, you're able to load & execute commands.
 
 Check out the [sniff](./sniff.md) module for detecting if your environment is able to run.
 
-Here's what we're about to cover.
+Here's a kitchen sink version, which we're about to cover.
 
 ```js
 const { build } = 'gluegun'
 
-const cli = build()
-  .brand('movie')
+const cli = build('movie')
   .src(__dirname)
   .plugin('~/.movie/movie-imdb')
   .plugins('./node_modules', { pattern: 'movie-' })
@@ -16,6 +15,7 @@ const cli = build()
   .version()
   .defaultCommand()
   .command({ name: 'hi', run: toolbox => toolbox.print.info('hi!') })
+  .exclude(['filesystem', 'semver', 'system', 'prompt', 'http'])
   .create()
 
 await cli.run()
@@ -32,47 +32,16 @@ const { build } = require('gluegun')
 Now let's build a `gluegun` cli environment by configuring various features.
 
 ```js
-const cli = build()
+const cli = build('mycli')
 ```
 
-But out of the box, it does very little. And by very little I mean nothing. So let's configure this.
-
-We'll be chaining the `build()` function from here.
-
-## brand
-
-**Brand** is used through-out the glue for things like configuration file names and folder names for plugins.
+The `mycli` brand that you pass into `build` is used through-out gluegun for things like configuration file names and folder names for plugins. You can also set it later, like this:
 
 ```js
 const cli = build().brand('movie')
 ```
 
-The brand is most likely to share the same name of the CLI.
-
-## exclude
-
-If you don't need certain core extensions, you can skip loading them (thus improving startup time) by using `.exclude()`. Just pass in an array of string names for the core extensions you don't need. Just make sure this appears before the `.src()` command (documented below).
-
-```js
-const cli = build()
-  .brand('movie')
-  .exclude(['meta', 'strings', 'print', 'filesystem', 'semver', 'system', 'prompt', 'http', 'template', 'patching'])
-```
-
-If you find you need one of these extensions for just _one_ command but don't want to load it for _all_ of your commands, you can always load it separately from the Gluegun toolbox, like this:
-
-```js
-const { prompt } = require('gluegun/toolbox')
-```
-
-For reference, the core extensions that incur the biggest startup performance penalty are (timing varies per machine, but this gives some sense of scale):
-
-```
-prompt +100ms
-print +45ms
-http +30ms
-system +10ms
-```
+Out of the box, this CLI does very little. And by very little I mean nothing. So let's configure this. We'll be chaining the `build()` function from here.
 
 ## src
 
@@ -80,9 +49,7 @@ This sets where the default commands and extensions are located, in
 `commands` and `extensions` folders, respectively.
 
 ```js
-const cli = build()
-  .brand('movie')
-  .src(__dirname)
+const cli = build('movie').src(__dirname)
 ```
 
 When you run a command, it'll first load extensions in this folder and then check the commands in this folder for the right command.
@@ -116,8 +83,7 @@ movie-credits
 You can load a plugin from a directory:
 
 ```js
-const cli = build()
-  .brand('movie')
+const cli = build('movie')
   .src(__dirname)
   .plugin('~/.movie/movie-imdb')
 ```
@@ -127,8 +93,7 @@ const cli = build()
 You can also load multiple plugins within a directory.
 
 ```js
-const cli = build()
-  .brand('movie')
+const cli = build('movie')
   .src(__dirname)
   .plugin('~/.movie/movie-imdb')
   .plugins('./node_modules', { pattern: 'movie-' })
@@ -154,8 +119,7 @@ Gluegun ships with a somewhat adequate `help` screen out of the box. Add it to y
 CLI easily by calling `.help()`.
 
 ```js
-const cli = build()
-  .brand('movie')
+const cli = build('movie')
   .src(__dirname)
   .plugins('./node_modules', { pattern: 'movie-' })
   .plugin('~/.movie/movie-imdb')
@@ -181,8 +145,7 @@ You usually like to be able to run `--version` to see your CLI's version from th
 line, so add it easily with `.version()`.
 
 ```js
-const cli = build()
-  .brand('movie')
+const cli = build('movie')
   .src(__dirname)
   .plugins('./node_modules', { pattern: 'movie-' })
   .plugin('~/.movie/movie-imdb')
@@ -199,8 +162,7 @@ instead. Note that you can do this by supplying a `<brand>.js` file in your `./c
 folder as well.
 
 ```js
-const cli = build()
-  .brand('movie')
+const cli = build('movie')
   .src(__dirname)
   .plugins('./node_modules', { pattern: 'movie-' })
   .plugin('~/.movie/movie-imdb')
@@ -217,8 +179,7 @@ you prefer more control.
 If you want to pass in arbitrary commands, you can do that with `.command()`.
 
 ```js
-const cli = build()
-  .brand('movie')
+const cli = build('movie')
   .src(__dirname)
   .plugins('./node_modules', { pattern: 'movie-' })
   .plugin('~/.movie/movie-imdb')
@@ -233,13 +194,46 @@ In this case, if you ran `movie hi`, it would run the function provided and prin
 You must provide an object with at least a `name` and a `run` function, which can be
 `async` or regular.
 
+## exclude
+
+If you don't need certain core extensions, you can skip loading them (thus improving startup time) by using `.exclude()`. Just pass in an array of string names for the core extensions you don't need.
+
+```js
+const cli = build('movie').exclude([
+  'meta',
+  'strings',
+  'print',
+  'filesystem',
+  'semver',
+  'system',
+  'prompt',
+  'http',
+  'template',
+  'patching',
+])
+```
+
+If you find you need one of these extensions for just _one_ command but don't want to load it for _all_ of your commands, you can always load it separately from the Gluegun toolbox, like this:
+
+```js
+const { prompt } = require('gluegun/toolbox')
+```
+
+For reference, the core extensions that incur the biggest startup performance penalty are (timing varies per machine, but this gives some sense of scale):
+
+```
+prompt +100ms
+print +45ms
+http +30ms
+system +10ms
+```
+
 ## create
 
 At this point, we've been configuring our CLI. When we're ready, we call `create()`:
 
 ```js
-const cli = build()
-  .brand('movie')
+const cli = build('movie')
   .src(__dirname)
   .plugins('./node_modules', { pattern: 'movie-' })
   .plugin('~/.movie/movie-imdb')

--- a/readme.md
+++ b/readme.md
@@ -64,8 +64,7 @@ Let's start with what a `gluegun` CLI looks like.
 const { build } = require('gluegun')
 
 // aim
-const movieCLI = build()
-  .brand('movie')
+const movieCLI = build('movie')
   .src(`${__dirname}/core-plugins`)
   .plugins('node_modules', { matching: 'movie-*' })
   .help()

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -5,12 +5,11 @@ import { build, GluegunToolbox } from '../index'
  */
 export async function run(argv?: string[] | string): Promise<GluegunToolbox> {
   // create a CLI runtime
-  const cli = build()
-    .brand('gluegun')
-    .exclude(['semver', 'prompt', 'http', 'patching'])
+  const cli = build('gluegun')
     .src(__dirname)
     .help()
     .version()
+    .exclude(['semver', 'prompt', 'http', 'patching'])
     .create()
 
   // and run it

--- a/src/domain/builder.test.ts
+++ b/src/domain/builder.test.ts
@@ -18,9 +18,6 @@ test('the gauntlet', t => {
     .plugin(`${__dirname}/../fixtures/good-plugins/simplest`)
     .plugins(`${__dirname}/../fixtures/good-plugins`, { hidden: true })
 
-  // test the builder
-  t.is(builder.runtime.brand, 'test')
-
   const runtime = builder.create()
   t.truthy(runtime)
 

--- a/src/domain/builder.test.ts
+++ b/src/domain/builder.test.ts
@@ -3,9 +3,7 @@ import { build } from './builder'
 import { Toolbox } from './toolbox'
 
 test('the gauntlet', t => {
-  const brand = 'test'
-  const builder = build()
-    .brand(brand)
+  const builder = build('test')
     // plugins
     .src(`${__dirname}/../fixtures/good-plugins/threepack`)
     .help()
@@ -21,11 +19,12 @@ test('the gauntlet', t => {
   const runtime = builder.create()
   t.truthy(runtime)
 
+  t.is(runtime.brand, 'test')
   t.is(runtime.commands.length, 26)
   t.is(runtime.extensions.length, 13)
   t.is(runtime.defaultPlugin.commands.length, 6)
 
-  t.is(runtime.defaultPlugin.commands[0].name, brand)
+  t.is(runtime.defaultPlugin.commands[0].name, 'test')
   t.is(runtime.defaultPlugin.commands[1].name, 'gimmedatversion')
   t.is(runtime.defaultPlugin.commands[1].run(new Toolbox()), 'it works')
   t.is(runtime.defaultPlugin.commands[2].name, 'help')

--- a/src/domain/builder.ts
+++ b/src/domain/builder.ts
@@ -138,7 +138,6 @@ export class Builder {
    * @return self.
    */
   public command(command: GluegunCommand): Builder {
-    // this.data.addCommand(command)
     this.data.commands.push(command)
     return this
   }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -5,8 +5,10 @@ test('create', t => {
   t.truthy(exported)
   t.is(typeof exported.build, 'function')
   const { build } = exported
-  const runtime = build()
-    .brand('test')
-    .create()
+  const runtime = build('test').create()
   t.is(runtime.brand, 'test')
+  const runtime2 = build()
+    .brand('test2')
+    .create()
+  t.is(runtime2.brand, 'test2')
 })


### PR DESCRIPTION
*This patch is backwards-compatible.*

This change refactors the `Builder` class to allow options in any order. This builds on #357 and solves one of the annoyances I had with the builder API (which I, unfortunately, introduced in #307), which is that it became order-dependent. This now has an internal `data` object that holds the info until everything is loaded.

The one exception to the order-dependent is still the `.brand()` method (this was a requirement prior to #307 too). So I added an optional `brand?: string` argument to the `build()` function to make it more idiomatic to specify the brand up front.

```js
// old way -- still works!
const cli = build()
  .brand('mycli')
  // ...
  .create()

// new way -- documented
const cli = build('mycli')
  // ...
  .create()
```
