### PR TITLE
🏡 Adds toolbox.filesystem.homedir()

### DIFF
--- a/docs/toolbox-filesystem.md
+++ b/docs/toolbox-filesystem.md
@@ -18,6 +18,14 @@ This value is the end of line byte sequence.
 toolbox.filesystem.eol // '\n' on posix but '\r\n' on windows
 ```
 
+## homedir
+
+This function retrieves the path to the home directory.
+
+```js
+toolbox.filesystem.homedir() // '/Users/jh' on my macOS machine
+```
+
 ## subdirectories
 
 Finds the immediate subdirectories in a given directory.

--- a/src/core-extensions/filesystem-extension.ts
+++ b/src/core-extensions/filesystem-extension.ts
@@ -14,6 +14,7 @@ export default function attach(toolbox: GluegunToolbox) {
   const extension: GluegunFilesystem = Object.assign(
     {
       eol: os.EOL, // end of line marker
+      homedir: os.homedir, // get home directory
       separator: path.sep, // path separator
       subdirectories: subdirectories, // retrieve subdirectories
     },

--- a/src/core-extensions/filesystem-types.ts
+++ b/src/core-extensions/filesystem-types.ts
@@ -10,6 +10,11 @@ export interface GluegunFilesystem {
   separator: string
 
   /**
+   * Convenience property for `os.homedir` function
+   */
+  homedir: () => string
+
+  /**
    * Appends given data to the end of file. If file or any parent directory doesn't exist it will be created.
    *
    * @param path The path to the file.


### PR DESCRIPTION
To avoid certain [boneheaded issues](https://twitter.com/jamonholmgren/status/967548502648668161) by certain [boneheaded people](https://twitter.com/jamonholmgren), having a simple way to access the home directory would be useful.

```typescript
import { filesystem: { homedir } } from 'gluegun/toolbox'

homedir() // on my laptop, '/Users/jh'
```
