### PR TITLE
⌫ Removed vestigial code that was causing parameters to be malformed

### DIFF
--- a/src/runtime/runtime-parameters.test.ts
+++ b/src/runtime/runtime-parameters.test.ts
@@ -62,3 +62,16 @@ test('properly infers the heirarchy from folder structure', async () => {
   expect(parameters.options.foo).toBe(1)
   expect(parameters.options.force).toBe(true)
 })
+
+test('properly assembles parameters when command and first arg have same name', async () => {
+  const r = new Runtime()
+  r.addCoreExtensions()
+  r.addPlugin(`${__dirname}/../fixtures/good-plugins/threepack`)
+  const { command, parameters } = await r.run('one one two')
+
+  expect(command.commandPath).toEqual(['one'])
+  expect(parameters.string).toBe('one two')
+  expect(parameters.command).toBe('one')
+  expect(parameters.first).toBe('one')
+  expect(parameters.second).toBe('two')
+})

--- a/src/toolbox/parameter-tools.ts
+++ b/src/toolbox/parameter-tools.ts
@@ -39,19 +39,9 @@ export function parseParams(commandArray: string | string[], extraOpts: Options 
  */
 export function createParams(params: any): GluegunParameters {
   // make a copy of the args so we can mutate it
-  const array = params.array.slice()
+  const array: string[] = params.array.slice()
 
-  // Remove the first two elements from the array if they're the plugin and command
-  if (array[0] === params.plugin) {
-    array.shift()
-  }
-  if (array[0] === params.command) {
-    array.shift()
-  }
-
-  const first = array[0]
-  const second = array[1]
-  const third = array[2]
+  const [first, second, third] = array
 
   // the string is the rest of the words
   const finalString = array.join(' ')


### PR DESCRIPTION
Per @skellock , this would manifest itself this way:

`mycli test test foo` 

(where `mycli test` is the command and the second `test` being a parameter)

In this case it would put `foo` as `parameter.first`, where it should be `test`. This PR fixes that.
