### PR TITLE
Fix commands parsing issues on Windows

### DIFF
--- a/src/cli/cli.integration.ts
+++ b/src/cli/cli.integration.ts
@@ -33,7 +33,7 @@ test('can create a new boilerplate cli', async () => {
   expect(Object.keys(pkg.dependencies).includes('gluegun')).toBeTruthy()
 
   // Install local version of gluegun to test
-  await toolbox.system.run(`cd ${tmp}/foo && npm install ${pwd}`)
+  await toolbox.system.run(`cd ${tmp}/foo && yarn add ${pwd}`)
 
   // Try running the help command, see what it does
   const runCommand = await toolbox.system.run(`${tmp}/foo/bin/foo --help`)
@@ -63,7 +63,7 @@ test('can create a new boilerplate TypeScript cli', async () => {
   expect(Object.keys(pkg.dependencies).includes('gluegun')).toBeTruthy()
 
   // Install local version of gluegun to test
-  await toolbox.system.run(`cd ${tmp}/foo-ts && npm install ${pwd}`)
+  await toolbox.system.run(`cd ${tmp}/foo-ts && yarn add ${pwd}`)
 
   // Try running the help command, see what it does
   const runCommand = await toolbox.system.run(`${tmp}/foo-ts/bin/foo-ts --help`)

--- a/src/core-extensions/filesystem-extension.test.ts
+++ b/src/core-extensions/filesystem-extension.test.ts
@@ -16,7 +16,7 @@ test('has the proper interface', () => {
   expect(typeof ext.copy).toBe('function')
   expect(typeof ext.path).toBe('function')
   expect(typeof ext.subdirectories).toBe('function')
-  expect(split('\n', ext.read(__filename))[0]).toBe(`import * as expect from 'expect'`)
+  expect(split(os.EOL, ext.read(__filename))[0]).toBe(`import * as expect from 'expect'`)
   // the extra values we've added
   expect(ext.eol).toBe(os.EOL)
   expect(ext.separator).toBe(path.sep)

--- a/src/core-extensions/system-extension.test.ts
+++ b/src/core-extensions/system-extension.test.ts
@@ -23,7 +23,7 @@ test('captures stderr', async () => {
   try {
     await system.run(`omgdontrunlol ${__filename}`)
   } catch (e) {
-    expect(/not found/.test(e.stderr)).toBe(true)
+    expect(/not (found|recognized)/.test(e.stderr)).toBe(true)
   }
 })
 

--- a/src/core-extensions/template-extension.test.ts
+++ b/src/core-extensions/template-extension.test.ts
@@ -1,3 +1,4 @@
+import * as os from 'os'
 import * as expect from 'expect'
 import { startsWith } from 'ramdasauce'
 import { Runtime } from '../runtime/runtime'
@@ -12,7 +13,7 @@ const createRuntime = () => {
 test('generates a simple file', async () => {
   const toolbox = await createRuntime().run('simple')
 
-  expect(toolbox.result).toBe('simple file\n')
+  expect(toolbox.result).toBe('simple file' + os.EOL)
 })
 
 test('supports props', async () => {
@@ -20,12 +21,9 @@ test('supports props', async () => {
     stars: 5,
   })
 
-  expect(toolbox.result).toBe(`greetingsAndSalutations world
-red
-green
-blue
-*****
-`)
+  expect(toolbox.result).toBe(
+    `greetingsAndSalutations world${os.EOL}` + `red${os.EOL}green${os.EOL}blue${os.EOL}*****${os.EOL}`,
+  )
 })
 
 test('detects missing templates', async () => {
@@ -39,6 +37,5 @@ test('detects missing templates', async () => {
 test('supports directories', async () => {
   const toolbox = await createRuntime().run('special location')
 
-  expect(toolbox.result).toBe(`location
-`)
+  expect(toolbox.result).toBe('location' + os.EOL)
 })

--- a/src/loaders/command-loader.ts
+++ b/src/loaders/command-loader.ts
@@ -1,3 +1,4 @@
+import * as path from 'path'
 import { head, is, isNil, last, reject, split, takeLast } from 'ramda'
 import { Command, GluegunCommand } from '../domain/command'
 import { filesystem } from '../toolbox/filesystem-tools'
@@ -28,8 +29,9 @@ export function loadCommandFromFile(file: string, options: Options = {}): Comman
   command.file = file
   // default name is the name without the file extension
   command.name = head(split('.', (filesystem.inspect(file) as any).name))
+
   // strip the extension from the end of the commandPath
-  command.commandPath = (options.commandPath || last(file.split('/commands/')).split('/')).map(
+  command.commandPath = (options.commandPath || last(file.split('commands' + path.sep)).split(path.sep)).map(
     f => ([`${command.name}.js`, `${command.name}.ts`].includes(f) ? command.name : f),
   )
 

--- a/src/loaders/plugin-loader.test.ts
+++ b/src/loaders/plugin-loader.test.ts
@@ -1,3 +1,4 @@
+import * as path from 'path'
 import * as expect from 'expect'
 import { find, propEq } from 'ramda'
 import { Toolbox } from '../domain/toolbox'
@@ -40,7 +41,7 @@ test('loads commands', async () => {
 
   const two = find(propEq('name', 'two'), plugin.commands)
   expect(two.name).toBe('two')
-  expect(two.file).toBe(`${dir}/commands/two.js`)
+  expect(two.file).toBe(path.join(dir, 'commands', 'two.js'))
   expect(typeof two.run).toBe('function')
   expect(await two.run()).toBe('two')
   expect(plugin.commands[0].hidden).toBeFalsy()
@@ -57,7 +58,7 @@ test('load commands with front matter', async () => {
   // test the command
   const full = find(propEq('name', 'full'), plugin.commands)
   expect(full.name).toBe('full')
-  expect(full.file).toBe(`${dir}/commands/full.js`)
+  expect(full.file).toBe(path.join(dir, 'commands', 'full.js'))
   expect(typeof full.run).toBe('function')
   expect(await full.run()).toBe(123)
 })

--- a/src/loaders/plugin-loader.ts
+++ b/src/loaders/plugin-loader.ts
@@ -1,3 +1,4 @@
+import * as path from 'path'
 import * as jetpack from 'fs-jetpack'
 import { map } from 'ramda'
 import { Plugin } from '../domain/plugin'
@@ -53,7 +54,7 @@ export function loadPluginFromDirectory(directory: string, options: Options = {}
     const commands = jetpackPlugin.cwd('commands').find({ matching: commandFilePattern, recursive: true })
 
     plugin.commands = plugin.commands.concat(
-      map(file => loadCommandFromFile(`${directory}/commands/${file}`), commands),
+      map(file => loadCommandFromFile(path.join(directory, 'commands', file)), commands),
     )
   }
 

--- a/src/runtime/runtime-extensions.test.ts
+++ b/src/runtime/runtime-extensions.test.ts
@@ -5,7 +5,10 @@ import { Runtime } from './runtime'
 test('loads the core extensions in the right order', () => {
   const r = new Runtime()
   r.addCoreExtensions()
-  const list = pipe(pluck('name'), join(', '))(r.extensions)
+  const list = pipe(
+    pluck('name'),
+    join(', '),
+  )(r.extensions)
 
   expect(list).toBe('meta, strings, print, filesystem, semver, system, prompt, http, template, patching')
 })

--- a/src/toolbox/filesystem-tools.test.ts
+++ b/src/toolbox/filesystem-tools.test.ts
@@ -1,3 +1,4 @@
+import * as path from 'path'
 import * as expect from 'expect'
 import { contains } from 'ramda'
 import { filesystem } from './filesystem-tools'
@@ -25,7 +26,7 @@ test('isNotDirectory', () => {
 test('subdirectories', () => {
   const dirs = filesystem.subdirectories(`${__dirname}/..`)
   expect(dirs.length).toBe(8)
-  expect(contains(`${__dirname}/../toolbox`, dirs)).toBe(true)
+  expect(contains(path.join(__dirname, '..', 'toolbox'), dirs)).toBe(true)
 })
 
 test('blank subdirectories', () => {

--- a/src/toolbox/filesystem-tools.ts
+++ b/src/toolbox/filesystem-tools.ts
@@ -1,8 +1,8 @@
 import * as jetpack from 'fs-jetpack'
-import { complement, concat, map } from 'ramda'
+import { complement } from 'ramda'
 import { strings } from './string-tools'
 import * as os from 'os'
-import * as path from 'path'
+import * as pathlib from 'path'
 
 import { GluegunFilesystem } from './filesystem-types'
 
@@ -70,7 +70,7 @@ function subdirectories(
   if (isRelative) {
     return dirs
   } else {
-    return map(concat(`${path}/`), dirs)
+    return dirs.map(dir => pathlib.join(path, dir))
   }
 }
 
@@ -78,7 +78,7 @@ const filesystem: GluegunFilesystem = Object.assign(
   {
     eol: os.EOL, // end of line marker
     homedir: os.homedir, // get home directory
-    separator: path.sep, // path separator
+    separator: pathlib.sep, // path separator
     subdirectories, // retrieve subdirectories
     isFile,
     isNotFile,

--- a/src/toolbox/string-tools.ts
+++ b/src/toolbox/string-tools.ts
@@ -55,7 +55,10 @@ function identity(value: any): any {
  * @returns PascalCase string.
  */
 function pascalCase(value: string): string {
-  return pipe(camelCase, upperFirst)(value) as string
+  return pipe(
+    camelCase,
+    upperFirst,
+  )(value) as string
 }
 
 export { GluegunStrings }


### PR DESCRIPTION
Hi,
This PR is related to issue #384.

Subcommands are not resolved properly on Windows.

Also added some fixes to get tests to pass on Windows.