### PR TITLE
Fix command name printing

### DIFF
--- a/src/toolbox/meta-tools.ts
+++ b/src/toolbox/meta-tools.ts
@@ -59,10 +59,7 @@ export function commandInfo(toolbox: GluegunToolbox, commandRoot?: string[]): st
     }),
     map(command => {
       const alias = command.hasAlias() ? `(${command.aliases.join(', ')})` : ''
-      return [
-        `${command.commandPath.join(' ')} ${alias}`,
-        replace('$BRAND', toolbox.runtime.brand, command.description || '-'),
-      ]
+      return [`${command.name} ${alias}`, replace('$BRAND', toolbox.runtime.brand, command.description || '-')]
     }),
   )(toolbox.runtime.commands)
 }


### PR DESCRIPTION
I have the following command

```
module.exports = {
  name: 'app.build',
  dashed: false,
  description: 'Build an application',
  run,
};
```

Under the file `build.js`

When I run `yarn cli --help` the output shows me `build` as an available command but this is not true, the command name is actually `app.build`