### PR TITLE
Fix system.which command

### DIFF
--- a/src/toolbox/system-tools.test.ts
+++ b/src/toolbox/system-tools.test.ts
@@ -2,7 +2,7 @@ import * as expect from 'expect'
 import { system } from './system-tools'
 
 test('which - existing package', () => {
-  const result = system.which('git')
+  const result = system.which('node')
   expect(result).not.toBe(null)
 })
 

--- a/src/toolbox/system-tools.test.ts
+++ b/src/toolbox/system-tools.test.ts
@@ -1,0 +1,12 @@
+import * as expect from 'expect'
+import { system } from './system-tools'
+
+test('which - existing package', () => {
+  const result = system.which('git')
+  expect(result).not.toBe(null)
+})
+
+test('which - non-existing package', () => {
+  const result = system.which('non-existing-package')
+  expect(result).toBe(null)
+})

--- a/src/toolbox/system-tools.ts
+++ b/src/toolbox/system-tools.ts
@@ -87,7 +87,7 @@ async function spawn(commandLine: string, options: Options = {}): Promise<any> {
  * @return The full path or null.
  */
 function which(command: string): string | null {
-  return nodeWhich.sync(command)
+  return nodeWhich.sync(command, { nothrow: true })
 }
 
 /**


### PR DESCRIPTION
If the command doesn't exist, `system.which` throws an error.  Based on the comments and return values, it shouldn't throw an error.  An example of where this is used and fails (if `git` not found): [Bowser Boilerplate](https://github.com/infinitered/ignite-ir-boilerplate-bowser/blob/master/boilerplate.js#L232)

[npm which docs](https://www.npmjs.com/package/which)

I added a test checking for `git` I'm guessing is present on any machine running the tests.  If anyone has a better idea, let me know