### PR TITLE
feat: Replace ava in favor of jest

### DIFF
--- a/src/cli/templates/cli/package.json.ejs
+++ b/src/cli/templates/cli/package.json.ejs
@@ -13,9 +13,10 @@
       "format": "prettier --write **/*.{js,json} && standard --fix",
       "lint": "standard",
     <% } %>
-    "test": "ava",
-    "watch": "ava --watch",
-    "coverage": "nyc ava"
+    "test": "jest",
+    "watch": "jest --watch",
+    "snapupdate": "jest --updateSnapshot",
+    "coverage": "jest --coverage"
   },
   "files": [
     <% if (props.typescript) { %>
@@ -38,13 +39,13 @@
   "devDependencies": {
     <% if (props.typescript) { %>
       "@types/node": "^10.12.12",
+      "ts-jest": "^23.10.5",
     <% } else { %>
       "standard": "^12.0.1",
       "babel-eslint": "^10.0.1",
     <% } %>
     "prettier": "^1.12.1",
-    "ava": "^1.0.0",
-    "nyc": "^13.1.0"
+    "jest": "^23.6.0"
   }
   <% if (!props.typescript) { %>,
     "standard": {


### PR DESCRIPTION
The generated packages still use ava and not jest

Resolves: #406