### PR TITLE
Typescript improvement to CLI commands

### DIFF
--- a/src/cli/templates/cli/src/commands/default.js.ejs
+++ b/src/cli/templates/cli/src/commands/default.js.ejs
@@ -1,6 +1,10 @@
+<% if (props.typescript) { %>
+import { GluegunToolbox } from 'gluegun'
+<% } %>
+
 module.exports = {
   name: '<%= props.name %>',
-  run: async toolbox => {
+  run: async <%= (props.typescript) ? "(toolbox: GluegunToolbox)" : "toolbox" %> => {
     const { print } = toolbox
 
     print.info('Welcome to your CLI')

--- a/src/cli/templates/cli/src/commands/generate.js.ejs
+++ b/src/cli/templates/cli/src/commands/generate.js.ejs
@@ -1,7 +1,11 @@
+<% if (props.typescript) { %>
+  import { GluegunToolbox } from 'gluegun'
+  <% } %>  
+
 module.exports = {
   name: 'generate',
   alias: ['g'],
-  run: async toolbox => {
+  run: async <%= (props.typescript) ? "(toolbox: GluegunToolbox)" : "toolbox" %> => {
     const {
       parameters,
       template: { generate },


### PR DESCRIPTION
Generated TypeScript CLIs will now have the most basic `GluegunToolbox` types added, since this can be unintuitive.