### PR TITLE
Adds shortcut to speed up --version in gluegun CLI

### DIFF
--- a/bin/gluegun
+++ b/bin/gluegun
@@ -1,5 +1,15 @@
 #!/usr/bin/env node
 
+/* tslint:disable */
+
+// speed up `gluegun --version` et al
+if (['-v', '--v', '-version', '--version'].includes(process.argv[2])) {
+  var contents = require('fs').readFileSync(__dirname + '/../package.json')
+  var package = JSON.parse(contents)
+  console.log(package.version)
+  process.exit(0)
+}
+
 // check if we're running in dev mode
 var devMode = require('fs').existsSync(`${__dirname}/../src`)
 var wantsCompiled = process.argv.indexOf('--compiled-gluegun') >= 0

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,7 @@
 [![npm module](https://badge.fury.io/js/gluegun.svg)](https://www.npmjs.org/package/gluegun)
-[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors)
-[![Build Status](https://semaphoreci.com/api/v1/ir/gluegun/branches/master/shields_badge.svg)](https://semaphoreci.com/ir/gluegun)
-[![Coverage Status](https://coveralls.io/repos/github/infinitered/gluegun/badge.svg?branch=master)](https://coveralls.io/github/infinitered/gluegun?branch=master)
+[![CircleCI](https://circleci.com/gh/infinitered/gluegun.svg?style=svg)](https://circleci.com/gh/infinitered/gluegun)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
-[![Chat about GlueGun in the IR Community](https://infiniteredcommunity.herokuapp.com/badge.svg)](https://community.infinite.red/)
+[![Chat about GlueGun in the IR Community](http://infiniteredcommunity.herokuapp.com/badge.svg)](https://community.infinite.red/)
 
 # Gluegun
 


### PR DESCRIPTION
Since `gluegun --version` is a common (and simple) command, we avoid loading up everything in Gluegun with this quick shortcut.