### PR TITLE
Adds loadConfig function to toolbox.config object

### DIFF
--- a/docs/toolbox-config.md
+++ b/docs/toolbox-config.md
@@ -33,7 +33,54 @@ module.exports = {
 It takes the plugin's defaults, and merges the user's changes overtop.
 
 ```js
-module.exports = async function(toolbox) {
+module.exports = async toolbox => {
   toolbox.config.movies // { fun: true, level: 10 }
 }
 ```
+
+If you'd like to load your own config files, use the `loadConfig` function included in the config object which is powered by [cosmiconfig](https://github.com/davidtheclark/cosmiconfig):
+
+```js
+module.exports = {
+  run: async toolbox => {
+    const {
+      config: { loadConfig },
+      print: { info },
+      runtime: { brand },
+    } = toolbox
+
+    // use cosmiconfig directly: directory (string) & brand (string)
+    const myConfig = loadConfig(process.cwd(), brand)
+    // or
+    const myConfig = loadConfig('~/.myconfig/', 'movie')
+
+    // now access myConfig
+    info(myConfig.shirtSize)
+
+    // if you want to load multiple configs and have them override:
+    const currentFolder = process.cwd()
+    const myConfig = {
+      ...loadConfig('~/.myconfig/', 'movies'),
+      ...loadConfig('~/configurations/myconfig/', 'movies'),
+      ...loadConfig(currentFolder, 'movies'),
+    }
+  },
+}
+```
+
+By default, Cosmiconfig will start where you tell it to start and search up the directory tree for the following:
+
+- a package.json property
+- a JSON or YAML, extensionless "rc file"
+- an "rc file" with the extensions .json, .yaml, .yml, or .js.
+- a .config.js CommonJS module
+
+For example, if your module's name is "soursocks", cosmiconfig will search up the directory tree for configuration in the following places:
+
+- a soursocks property in package.json
+- a .soursocksrc file in JSON or YAML format
+- a .soursocksrc.json file
+- a .soursocksrc.yaml, .soursocksrc.yml, or .soursocksrc.js file
+- a soursocks.config.js file exporting a JS object
+
+Cosmiconfig continues to search up the directory tree, checking each of these places in each directory, until it finds some acceptable configuration (or hits the home directory).

--- a/src/cli/templates/cli/__tests__/cli-integration.test.js.ejs
+++ b/src/cli/templates/cli/__tests__/cli-integration.test.js.ejs
@@ -1,9 +1,8 @@
 const { system, filesystem } = require('gluegun')
-const { resolve } = require('path')
 
-const src = resolve(__dirname, '..')
+const src = filesystem.path(__dirname, '..')
 
-const cli = async cmd => system.run('node ' + resolve(src, 'bin', '<%= props.name %>') + ` ${cmd}`)
+const cli = async cmd => system.run('node ' + filesystem.path(src, 'bin', '<%= props.name %>') + ` ${cmd}`)
 
 test('outputs version', async () => {
   const output = await cli('--version')

--- a/src/cli/templates/cli/src/extensions/cli-extension.js.ejs
+++ b/src/cli/templates/cli/src/extensions/cli-extension.js.ejs
@@ -4,4 +4,12 @@ module.exports = toolbox => {
   toolbox.foo = () => {
     console.log('called foo extension')
   }
+
+  // enable this if you want to read configuration in from
+  // the current folder's package.json (in a "<%= props.name %>" property),
+  // <%= props.name %>.config.json, etc.
+  // toolbox.config = {
+  //   ...toolbox.config,
+  //   ...toolbox.config.loadConfig(process.cwd(), "<%= props.name %>")
+  // }
 }

--- a/src/domain/toolbox.ts
+++ b/src/domain/toolbox.ts
@@ -73,7 +73,7 @@ export interface GluegunToolbox {
 export class Toolbox implements GluegunToolbox {
   [x: string]: any
   public result = null
-  public config: Options = {}
+  public config: Options & { loadConfig?: (name: string, src: string) => Options } = {}
   public parameters: GluegunParameters = {}
   public plugin?: Plugin = null
   public command?: Command = null

--- a/src/runtime/run.ts
+++ b/src/runtime/run.ts
@@ -4,6 +4,7 @@ import { createParams, parseParams } from '../toolbox/parameter-tools'
 import { Runtime } from './runtime'
 import { findCommand } from './runtime-find-command'
 import { Options } from '../domain/options'
+import { loadConfig } from '../loaders/config-loader'
 
 /**
  * Runs a command.
@@ -55,6 +56,9 @@ export async function run(this: Runtime, rawCommand?: string | string[], extraOp
     toolbox.plugin.defaults,
     (this.defaults && this.defaults[toolbox.plugin.name]) || {},
   )
+
+  // expose cosmiconfig
+  toolbox.config.loadConfig = loadConfig
 
   // kick it off
   if (toolbox.command.run) {

--- a/src/toolbox/meta-tools.ts
+++ b/src/toolbox/meta-tools.ts
@@ -1,6 +1,7 @@
 import * as jetpack from 'fs-jetpack'
 import { equals, map, pipe, propEq, reject, replace } from 'ramda'
 import { GluegunToolbox } from '../domain/toolbox'
+
 /**
  * Finds the version for the currently running CLI.
  *


### PR DESCRIPTION
It's often quite helpful to load configuration using Cosmiconfig. This adds Cosmiconfig to the `toolbox.config` object so it's easy to access.

```js
const defaultConfig = {
  shape: "Hexagon"
}

const { config: { loadConfig } } = toolbox

const myConfig = {
  ...defaultConfig,
  ...loadConfig(process.cwd(), 'mycli')
}
```