### PR TITLE
#430 remove lock files from doc gitignore

### DIFF
--- a/src/cli/templates/cli/.gitignore.ejs
+++ b/src/cli/templates/cli/.gitignore.ejs
@@ -3,5 +3,3 @@ node_modules
 npm-debug.log
 coverage
 .nyc_output
-yarn.lock
-package.lock


### PR DESCRIPTION
Fixes #430 

This removes `lock` files from cli templates that are generated from user generated template. 
Since this is for the code that is generated for the user, both files should not be in `.gitignore` giving the user option to use either `yarn` or `npm`

#434 fixes this in the global package. 