### PR TITLE
Strengthens GluegunToolbox type guarantee

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -232,6 +232,27 @@ http +30ms
 system +10ms
 ```
 
+_Note about TypeScript and `exclude`:_ Please note that the TypeScript type `GluegunToolbox` (as of Gluegun 2.1.x) always assumes that core extensions are included, even if you excluded them in the builder. In this case, it's recommended that you create your own `FooToolbox` (or similar) and update the interface to match your preferred configuration. Example:
+
+```typescript
+// wherever your types are, say, `./src/types.ts`
+import { GluegunToolbox } from 'gluegun'
+export interface FooToolbox extends GluegunToolbox {
+  prompt: null
+  print: null
+  http: null
+  system: null
+}
+
+// in a command
+import { FooToolbox } from '../types'
+module.exports = {
+  run: async (toolbox: FooToolbox) => {
+    // ... use toolbox with your excluded extensions
+  },
+}
+```
+
 ## create
 
 At this point, we've been configuring our CLI. When we're ready, we call `create()`:

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -9,6 +9,14 @@ export async function run(argv?: string[] | string): Promise<GluegunToolbox> {
     .src(__dirname)
     .help()
     .version()
+    .defaultCommand({
+      run: async (toolbox: GluegunToolbox) => {
+        const { print, meta } = toolbox
+        print.info(`Gluegun version ${meta.version()}`)
+        print.info(``)
+        print.info(`  Type gluegun --help for more info`)
+      },
+    })
     .exclude(['semver', 'prompt', 'http', 'patching'])
     .create()
 

--- a/src/cli/commands/new.test.ts
+++ b/src/cli/commands/new.test.ts
@@ -9,6 +9,10 @@ sinon.stub(console, 'log')
 function createFakeToolbox(): Toolbox {
   const fakeToolbox = new Toolbox()
   fakeToolbox.strings = strings
+  fakeToolbox.meta = {
+    version: sinon.stub(),
+    commandInfo: sinon.stub(),
+  }
   fakeToolbox.filesystem = {
     resolve: sinon.stub(),
     dir: sinon.stub(),
@@ -21,6 +25,10 @@ function createFakeToolbox(): Toolbox {
   } as any
   fakeToolbox.template = { generate: sinon.stub() }
   fakeToolbox.print = {
+    colors: {
+      green: sinon.stub(),
+      gray: sinon.stub(),
+    },
     info: sinon.stub(),
     error: sinon.stub(),
   } as any

--- a/src/cli/commands/new.test.ts
+++ b/src/cli/commands/new.test.ts
@@ -10,6 +10,7 @@ function createFakeToolbox(): Toolbox {
   const fakeToolbox = new Toolbox()
   fakeToolbox.strings = strings
   fakeToolbox.meta = {
+    src: '',
     version: sinon.stub(),
     commandInfo: sinon.stub(),
   }

--- a/src/cli/commands/new.ts
+++ b/src/cli/commands/new.ts
@@ -13,8 +13,10 @@ const NewCommand: GluegunCommand = {
       print,
       strings,
       system,
+      meta,
     } = toolbox
     const { kebabCase } = strings
+    const { colors } = print
 
     const props = {
       name: parameters.first,
@@ -96,7 +98,7 @@ const NewCommand: GluegunCommand = {
       stderr: 'inherit',
     })
 
-    print.info(`Generated ${props.name} CLI.`)
+    print.info(colors.green(`Generated ${props.name} CLI with Gluegun ${meta.version()}.`))
     print.info(``)
     print.info(`Next:`)
     print.info(`  $ cd ${props.name}`)
@@ -105,12 +107,12 @@ const NewCommand: GluegunCommand = {
     print.info(`  $ ${props.name}`)
     print.info(``)
     if (props.typescript) {
-      print.info(`Since you generated a TypeScript project, we've included a build script.`)
-      print.info(`When you link and run the project, it will use ts-node locally to test.`)
-      print.info(`However, you can test the generated JavaScript locally like this:`)
+      print.info(colors.gray(`Since you generated a TypeScript project, we've included a build script.`))
+      print.info(colors.gray(`When you link and run the project, it will use ts-node locally to test.`))
+      print.info(colors.gray(`However, you can test the generated JavaScript locally like this:`))
       print.info(``)
       print.info(`  $ ${yarnOrNpm} build`)
-      print.info(`  $ ${yarnOrNpm} --compiled-build`)
+      print.info(`  $ ${props.name} --compiled-build`)
       print.info(``)
     }
 

--- a/src/cli/commands/new.ts
+++ b/src/cli/commands/new.ts
@@ -104,6 +104,15 @@ const NewCommand: GluegunCommand = {
     print.info(`  $ ${yarnOrNpm} link`)
     print.info(`  $ ${props.name}`)
     print.info(``)
+    if (props.typescript) {
+      print.info(`Since you generated a TypeScript project, we've included a build script.`)
+      print.info(`When you link and run the project, it will use ts-node locally to test.`)
+      print.info(`However, you can test the generated JavaScript locally like this:`)
+      print.info(``)
+      print.info(`  $ ${yarnOrNpm} build`)
+      print.info(`  $ ${yarnOrNpm} --compiled-build`)
+      print.info(``)
+    }
 
     // for tests
     return `new ${toolbox.parameters.first}`

--- a/src/cli/commands/new.ts
+++ b/src/cli/commands/new.ts
@@ -1,11 +1,12 @@
 import { GluegunCommand } from '../../domain/command'
+import { GluegunToolbox } from '../../domain/toolbox'
 
 const NewCommand: GluegunCommand = {
   name: 'new',
   alias: ['n', 'create'],
   description: 'Creates a new gluegun cli',
   hidden: false,
-  run: async toolbox => {
+  run: async (toolbox: GluegunToolbox) => {
     const {
       parameters,
       template: { generate },

--- a/src/cli/extensions/cli-extension.ts
+++ b/src/cli/extensions/cli-extension.ts
@@ -1,7 +1,8 @@
 import { chmodSync } from 'fs'
 import { resolve } from 'path'
+import { GluegunToolbox } from '../../domain/toolbox'
 
-export default toolbox => {
+export default (toolbox: GluegunToolbox) => {
   toolbox.filesystem.resolve = resolve
   toolbox.filesystem.chmodSync = chmodSync
 }

--- a/src/cli/templates/cli/.gitignore.ejs
+++ b/src/cli/templates/cli/.gitignore.ejs
@@ -3,3 +3,5 @@ node_modules
 npm-debug.log
 coverage
 .nyc_output
+dist/**/*
+build/**/*

--- a/src/cli/templates/cli/.gitignore.ejs
+++ b/src/cli/templates/cli/.gitignore.ejs
@@ -3,5 +3,5 @@ node_modules
 npm-debug.log
 coverage
 .nyc_output
-dist/**/*
-build/**/*
+dist
+build

--- a/src/cli/templates/cli/bin/cli-executable.ejs
+++ b/src/cli/templates/cli/bin/cli-executable.ejs
@@ -1,14 +1,25 @@
 #!/usr/bin/env node
 
 <% if (props.typescript) { %>
-// hook into ts-node so we can run typescript on the fly
-require('ts-node').register({
-  // Enable this if you need `.d.ts` files to be loaded.
-  // Read `ts-node` for more information https://www.npmjs.com/package/ts-node#help-my-types-are-missing
-  // files: true,
-  project: `${__dirname}/../tsconfig.json`
-});
-<% } %>
+/* tslint:disable */
+// check if we're running in dev mode
+var devMode = require('fs').existsSync(`${__dirname}/../src`)
+// or want to "force" running the compiled version with --compiled-build
+var wantsCompiled = process.argv.indexOf('--compiled-build') >= 0
 
+if (wantsCompiled || !devMode) {
+  // this runs from the compiled javascript source
+  require(`${__dirname}/../build/cli`).run(process.argv)
+} else {
+  // this runs from the typescript source (for dev only)
+  // hook into ts-node so we can run typescript on the fly
+  require('ts-node').register({ project: `${__dirname}/../tsconfig.json` })
+  // run the CLI with the current process arguments
+  require(`${__dirname}/../src/cli`).run(process.argv)
+}
+
+<% } else { %>
 // run the CLI with the current process arguments
 require('../src/cli').run(process.argv)
+
+<% } %>

--- a/src/cli/templates/cli/package.json.ejs
+++ b/src/cli/templates/cli/package.json.ejs
@@ -10,6 +10,8 @@
     <% if (props.typescript) { %>
       "format": "prettier --write **/*.{js,ts,tsx,json}",
       "lint": "tslint -p .",
+      "compile": "tsc -p .",
+      "build": "yarn format && yarn lint && yarn compile",
     <% } else { %>
       "format": "prettier --write **/*.{js,json} && standard --fix",
       "lint": "standard",
@@ -23,12 +25,14 @@
     <% if (props.typescript) { %>
       "tsconfig.json",
       "tslint.json",
+      "build",
+    <% } else { %>
+      "src",
     <% } %>
     "LICENSE",
     "readme.md",
     "docs",
-    "bin",
-    "src"
+    "bin"
   ],
   "license": "MIT",
   "dependencies": {

--- a/src/cli/templates/cli/readme.md.ejs
+++ b/src/cli/templates/cli/readme.md.ejs
@@ -16,9 +16,7 @@ $ npm whoami
 $ npm lint
 $ npm test
 (if typescript, run `npm run build` here)
-$ npm pack
-$ npm publish <name of tgz file here>
-$ rm <name of tgz file here>
+$ npm publish
 ```
 
 # License

--- a/src/cli/templates/cli/readme.md.ejs
+++ b/src/cli/templates/cli/readme.md.ejs
@@ -2,6 +2,25 @@
 
 A CLI for <%= props.name %>.
 
+## Customizing your CLI
+
+Check out the documentation at https://github.com/infinitered/gluegun/tree/master/docs.
+
+## Publishing to NPM
+
+To package your CLI up for NPM, do this:
+
+```shell
+$ npm login
+$ npm whoami
+$ npm lint
+$ npm test
+(if typescript, run `npm run build` here)
+$ npm pack
+$ npm publish <name of tgz file here>
+$ rm <name of tgz file here>
+```
+
 # License
 
 MIT - see LICENSE

--- a/src/cli/templates/cli/src/extensions/cli-extension.js.ejs
+++ b/src/cli/templates/cli/src/extensions/cli-extension.js.ejs
@@ -1,7 +1,11 @@
+<% if (props.typescript) { %>
+import { GluegunToolbox } from 'gluegun'
+<% } %>
+  
 // add your CLI-specific functionality here, which will then be accessible
 // to your commands
-module.exports = toolbox => {
+module.exports = <%= (props.typescript) ? "(toolbox: GluegunToolbox)" : "toolbox" %> => {
   toolbox.foo = () => {
-    console.log('called foo extension')
+    toolbox.print.info('called foo extension')
   }
 }

--- a/src/domain/command.ts
+++ b/src/domain/command.ts
@@ -36,7 +36,7 @@ export class Command implements GluegunCommand<Toolbox> {
   public dashed
   public plugin
 
-  constructor() {
+  constructor(props?: GluegunCommand) {
     this.name = null
     this.description = null
     this.file = null
@@ -46,6 +46,7 @@ export class Command implements GluegunCommand<Toolbox> {
     this.alias = []
     this.dashed = false
     this.plugin = null
+    if (props) Object.assign(this, props)
   }
 
   /**

--- a/src/domain/extension.ts
+++ b/src/domain/extension.ts
@@ -1,4 +1,4 @@
-import { Toolbox } from './toolbox'
+import { EmptyToolbox } from './toolbox'
 
 /**
  * An extension will add functionality to the toolbox that each command will receive.
@@ -11,5 +11,5 @@ export class Extension {
   /** The file this extension comes from. */
   public file?: string = null
   /** The function used to attach functionality to the toolbox. */
-  public setup?: (toolbox: Toolbox) => void = null
+  public setup?: (toolbox: EmptyToolbox) => void = null
 }

--- a/src/domain/toolbox.ts
+++ b/src/domain/toolbox.ts
@@ -42,7 +42,13 @@ export interface GluegunParameters {
   command?: string
 }
 
-export interface GluegunToolbox {
+// Temporary toolbox while building
+export interface GluegunEmptyToolbox {
+  [key: string]: any
+}
+
+// Final toolbox
+export interface GluegunToolbox extends GluegunEmptyToolbox {
   // known properties
   result?: any
   config?: Options
@@ -54,36 +60,30 @@ export interface GluegunToolbox {
   runtime?: Runtime
 
   // known extensions
-  filesystem?: GluegunFilesystem
-  http?: GluegunHttp
-  meta?: GluegunMeta
-  patching?: GluegunPatching
-  print?: GluegunPrint
-  prompt?: GluegunPrompt
-  semver?: GluegunSemver
-  strings?: GluegunStrings
-  system?: GluegunSystem
-  template?: GluegunTemplate
-  generate?: any
-
-  // our catch-all! since we can add whatever to this object
-  [key: string]: any
+  filesystem: GluegunFilesystem
+  http: GluegunHttp
+  meta: GluegunMeta
+  patching: GluegunPatching
+  print: GluegunPrint
+  prompt: GluegunPrompt
+  semver: GluegunSemver
+  strings: GluegunStrings
+  system: GluegunSystem
+  template: GluegunTemplate
+  generate: any
 }
 
-export class Toolbox implements GluegunToolbox {
+export class EmptyToolbox implements GluegunEmptyToolbox {
   [x: string]: any
-  public result = null
-  public config: Options = {}
-  public parameters: GluegunParameters = {
-    options: {},
-  }
+  public result?: any = null
+  public config?: Options = {}
+  public parameters?: GluegunParameters = { options: {} }
   public plugin?: Plugin = null
   public command?: Command = null
   public pluginName?: string = null
   public commandName?: string = null
   public runtime?: Runtime = null
 
-  // known extensions
   filesystem?: GluegunFilesystem
   http?: GluegunHttp
   meta?: GluegunMeta
@@ -95,6 +95,24 @@ export class Toolbox implements GluegunToolbox {
   system?: GluegunSystem
   template?: GluegunTemplate
   generate?: any
+}
+
+export class Toolbox extends EmptyToolbox implements GluegunToolbox {
+  public config: Options = {}
+  public parameters: GluegunParameters = { options: {} }
+
+  // known extensions
+  filesystem: GluegunFilesystem
+  http: GluegunHttp
+  meta: GluegunMeta
+  patching: GluegunPatching
+  print: GluegunPrint
+  prompt: GluegunPrompt
+  semver: GluegunSemver
+  strings: GluegunStrings
+  system: GluegunSystem
+  template: GluegunTemplate
+  generate: any
 }
 
 // Toolbox used to be known as RunContext. This is for backwards compatibility.

--- a/src/loaders/extension-loader.ts
+++ b/src/loaders/extension-loader.ts
@@ -2,6 +2,7 @@ import { Extension } from '../domain/extension'
 import { filesystem } from '../toolbox/filesystem-tools'
 import { strings } from '../toolbox/string-tools'
 import { loadModule } from './module-loader'
+import { EmptyToolbox, Toolbox } from '../domain/toolbox'
 
 /**
  * Loads the extension from a file.
@@ -37,7 +38,7 @@ export function loadExtensionFromFile(file: string, options = {}): Extension {
   const valid = extensionModule && typeof extensionModule === 'function'
 
   if (valid) {
-    extension.setup = extensionModule
+    extension.setup = (toolbox: EmptyToolbox) => void extensionModule(toolbox as Toolbox)
   } else {
     throw new Error(`Error: couldn't load ${extension.name}. Expected a function, got ${extensionModule}.`)
   }

--- a/src/runtime/run.ts
+++ b/src/runtime/run.ts
@@ -1,5 +1,4 @@
-import { isNil } from '../toolbox/utils'
-import { Toolbox } from '../domain/toolbox'
+import { EmptyToolbox, GluegunToolbox } from '../domain/toolbox'
 import { createParams, parseParams } from '../toolbox/parameter-tools'
 import { Runtime } from './runtime'
 import { findCommand } from './runtime-find-command'
@@ -12,12 +11,16 @@ import { Options } from '../domain/options'
  * @param extraOptions Additional options use to execute a command.
  * @return The Toolbox object indicating what happened.
  */
-export async function run(this: Runtime, rawCommand?: string | string[], extraOptions: Options = {}): Promise<Toolbox> {
+export async function run(
+  this: Runtime,
+  rawCommand?: string | string[],
+  extraOptions: Options = {},
+): Promise<GluegunToolbox> {
   // use provided rawCommand or process arguments if none given
   rawCommand = rawCommand || process.argv
 
   // prepare the run toolbox
-  const toolbox = new Toolbox()
+  let toolbox = new EmptyToolbox()
 
   // attach the runtime
   toolbox.runtime = this
@@ -28,12 +31,9 @@ export async function run(this: Runtime, rawCommand?: string | string[], extraOp
   // find the command, and parse out aliases
   const { command, array } = findCommand(this, toolbox.parameters)
 
-  // jet if we have no command
-  if (isNil(command)) return toolbox
-
   // rebuild the parameters, now that we know the plugin and command
   toolbox.parameters = createParams({
-    plugin: command.plugin.name,
+    plugin: command.plugin && command.plugin.name,
     command: command.name,
     array,
     options: toolbox.parameters.options,
@@ -44,24 +44,29 @@ export async function run(this: Runtime, rawCommand?: string | string[], extraOp
   // set a few properties
   toolbox.plugin = command.plugin || this.defaultPlugin
   toolbox.command = command
-  toolbox.pluginName = toolbox.plugin.name
+  toolbox.pluginName = toolbox.plugin && toolbox.plugin.name
   toolbox.commandName = command.name
 
   // setup the config
   toolbox.config = { ...this.config }
-  toolbox.config[toolbox.plugin.name] = {
-    ...toolbox.plugin.defaults,
-    ...((this.defaults && this.defaults[toolbox.plugin.name]) || {}),
+  if (toolbox.pluginName) {
+    toolbox.config[toolbox.pluginName] = {
+      ...toolbox.plugin.defaults,
+      ...((this.defaults && this.defaults[toolbox.pluginName]) || {}),
+    }
   }
+
+  // allow extensions to attach themselves to the toolbox
+  this.extensions.forEach(extension => extension.setup(toolbox))
 
   // kick it off
   if (toolbox.command.run) {
-    // allow extensions to attach themselves to the toolbox
-    this.extensions.forEach(extension => extension.setup(toolbox))
-
     // run the command
-    toolbox.result = await toolbox.command.run(toolbox)
+    toolbox.result = await toolbox.command.run(toolbox as GluegunToolbox)
   }
 
-  return toolbox
+  // recast it
+  const finalToolbox = toolbox as GluegunToolbox
+
+  return finalToolbox
 }

--- a/src/runtime/runtime-find-command.ts
+++ b/src/runtime/runtime-find-command.ts
@@ -1,6 +1,6 @@
 import { Command } from '../domain/command'
 import { Runtime } from './runtime'
-import { GluegunParameters } from '../domain/toolbox'
+import { GluegunParameters, GluegunToolbox } from '../domain/toolbox'
 import { equals } from '../toolbox/utils'
 
 /**
@@ -11,7 +11,7 @@ import { equals } from '../toolbox/utils'
  * @param parameters The parameters passed in
  * @returns object with plugin, command, and array
  */
-export function findCommand(runtime: Runtime, parameters: GluegunParameters) {
+export function findCommand(runtime: Runtime, parameters: GluegunParameters): { command: Command; array: string[] } {
   // the commandPath, which could be something like:
   // > movie list actors 2015
   // [ 'list', 'actors', '2015' ]
@@ -23,9 +23,16 @@ export function findCommand(runtime: Runtime, parameters: GluegunParameters) {
   let tempPathRest = commandPath
   let commandPathRest = tempPathRest
 
+  // a fallback command
+  const commandNotFound = new Command({
+    run: (toolbox: GluegunToolbox) => {
+      throw new Error(`Couldn't find that command, and no default command set.`)
+    },
+  })
+
   // the resolved command will live here
   // start by setting it to the default command, in case we don't find one
-  let targetCommand: Command = runtime.defaultCommand
+  let targetCommand: Command = runtime.defaultCommand || commandNotFound
 
   // if the commandPath is empty, it could be a dashed command, like --help
   if (commandPath.length === 0) {

--- a/src/runtime/runtime-run-bad.test.ts
+++ b/src/runtime/runtime-run-bad.test.ts
@@ -4,8 +4,7 @@ import { Runtime } from './runtime'
 test('cannot find a command', async () => {
   const r = new Runtime()
   r.addCoreExtensions()
-  const toolbox = await r.run('bloo blah')
-  expect(toolbox.result).toBeFalsy()
+  await expect(r.run('bloo blah')).rejects.toThrow(`Couldn't find that command, and no default command set.`)
 })
 
 test('is fatally wounded by exceptions', async () => {

--- a/tslint.json
+++ b/tslint.json
@@ -2,5 +2,8 @@
   "extends": ["tslint-config-standard", "tslint-config-prettier"],
   "rules": {
     "strict-type-predicates": false
+  },
+  "linterOptions": {
+    "exclude": ["src/cli/templates/LICENSE.ejs", "src/cli/templates/.gitignore.ejs"]
   }
 }


### PR DESCRIPTION
Before this commit, `GluegunToolbox` had as optional various core extensions. This makes the core extensions non-optional (once the Toolbox is built) and introduces two new internal types, the interface `EmptyToolbox` and the class `GluegunEmptyToolbox`. These aren't intended to be used by CLI authors and not exported publicly.

This should be backwards-compatible, but my intention is to bump to 2.1.0 (as documentation pre-emptively says).

*Update:* There is one thing that will be not backwards-compatible, but is undocumented behavior -- if you didn't specify a default command, before, it would just quit without output. Now it throws an error. I had to update the `gluegun` CLI to include a default command.