### PR TITLE
Types proposal for `ask` GluegunPrompt method

### DIFF
--- a/src/toolbox/prompt-types.ts
+++ b/src/toolbox/prompt-types.ts
@@ -2,12 +2,12 @@ export interface GluegunPrompt {
   /* Prompts with a confirm message. */
   confirm(message: string): Promise<boolean>
   /* Prompts with a set of questions. */
-  ask(questions: QuestionType|QuestionType[]): AskResponse
+  ask(questions: GluegunQuestionType|GluegunQuestionType[]): GluegunAskResponse
   /* Returns a separator. */
   separator(): string
 }
 
-interface QuestionType {
+interface GluegunQuestionType {
   type: string
   name: string
   message: string
@@ -15,6 +15,6 @@ interface QuestionType {
   default?: string
 }
 
-interface AskResponse {
+interface GluegunAskResponse {
   [key: string]: string
 }

--- a/src/toolbox/prompt-types.ts
+++ b/src/toolbox/prompt-types.ts
@@ -2,7 +2,19 @@ export interface GluegunPrompt {
   /* Prompts with a confirm message. */
   confirm(message: string): Promise<boolean>
   /* Prompts with a set of questions. */
-  ask(questions: any): any
+  ask(questions: QuestionType): AskResponse
   /* Returns a separator. */
   separator(): string
+}
+
+interface QuestionType {
+  type: string
+  name: string
+  message: string
+  choices?: string[]
+  default?: string
+}
+
+interface AskResponse {
+  [key: string]: string
 }

--- a/src/toolbox/prompt-types.ts
+++ b/src/toolbox/prompt-types.ts
@@ -2,7 +2,7 @@ export interface GluegunPrompt {
   /* Prompts with a confirm message. */
   confirm(message: string): Promise<boolean>
   /* Prompts with a set of questions. */
-  ask(questions: QuestionType): AskResponse
+  ask(questions: QuestionType|QuestionType[]): AskResponse
   /* Returns a separator. */
   separator(): string
 }


### PR DESCRIPTION
I'm migrating one yeoman generator to use gluegun and I found this a good way to start contributing to it :)

this is the start, hopefully by the end of my migration I can contribute a little more.

It was a little to find all the docs needed to type this properly, if you can point me to the right direction, I can make this typedefs work for every case.

things that I would like to confirm:
- how many types of questions we accept?
- is there any validation we can do on answers?
- can we have optional questions OR ask things depending on previous answers?

let me know if this is something you are interested in getting some external help, I don't want to commit on this (I'm doing this on my spare time), but I guess this is helpful for everyone and why not contribute right?