### PR TITLE
Added types for print.spin (Ora)

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@types/cli-table2": "~0.2.2",
     "@types/jest": "^23.3.10",
     "@types/node": "^10.12.12",
+    "@types/ora": "^3.0.0",
     "@types/pluralize": "~0.0.29",
     "@types/ramda": "~0.25.42",
     "@types/sinon": "^7.0.2",

--- a/src/toolbox/print-types.ts
+++ b/src/toolbox/print-types.ts
@@ -1,6 +1,7 @@
 import { GluegunToolbox } from '../index'
 import * as CLITable from 'cli-table3'
 import * as importedColors from 'colors'
+import * as ora from 'ora'
 
 export type GluegunPrintColors = typeof importedColors & {
   highlight: (t: string) => string
@@ -42,7 +43,7 @@ export interface GluegunPrint {
   /* Prints a table of data (usually a 2-dimensional array). */
   table: (data: any, options?: any) => void
   /* An `ora`-powered spinner. */
-  spin(options?: any): any
+  spin(options?: ora.Options | string): ora.Ora
   /* Print help info for known CLI commands. */
   printCommands(toolbox: GluegunToolbox): void
   /* Prints help info, including version and commands. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -209,10 +209,17 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.10.tgz#4897974cc317bf99d4fe6af1efa15957fa9c94de"
   integrity sha512-DC8xTuW/6TYgvEg3HEXS7cu9OijFqprVDXXiOcdOKZCU/5PJNLZU37VVvmZHdtMiGOa8wAA/We+JzbdxFzQTRQ==
 
-"@types/node@^10.12.12":
+"@types/node@*", "@types/node@^10.12.12":
   version "10.12.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
   integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
+
+"@types/ora@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/ora/-/ora-3.0.0.tgz#fd30d5414e00fc4608cc7e18b565dceb57f4f66c"
+  integrity sha512-AOY050qkT67vf17bQFyHSjF615vs1yAeiHrpwh55BQCnpHi70LGJaLdrrl8YlvtAzDdXTWyYLs4kb6uQXiuHIg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/pluralize@~0.0.29":
   version "0.0.29"


### PR DESCRIPTION
Adds types for `toolbox.print.spin()` which is powered by Ora.