### PR TITLE
[minor improvement to `new` command] Print Language used and Make case insensitive

### DIFF
--- a/src/cli/commands/new.ts
+++ b/src/cli/commands/new.ts
@@ -65,8 +65,8 @@ const NewCommand: GluegunCommand = {
       })
 
       // we default to TypeScript if they just press "enter"
-      props.typescript = !answer || answer.includes('TypeScript')
-      info(``)
+      props.typescript = !answer || answer.toLowerCase().includes('typescript')
+      info(`Language used: ${props.typescript ? 'TypeScript' : 'Modern JavaScript'}`)
     }
 
     // normalize, so they can't pass both --typescript and --javascript


### PR DESCRIPTION
slight improvement to make the Which Language prompt case insensitive (experienced here https://github.com/infinitered/gluegun/issues/457) and also show the selected language. the real fix is to use some sort of picker and not rely on user string input.

modify as you wish!

