### PR TITLE
fix links to docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -99,9 +99,9 @@ module.exports = {
 }
 ```
 
-See the [toolbox api docs](./docs/toolbox-api.md) for more details on what you can do.
+See the [toolbox api docs](toolbox-api.md) for more details on what you can do.
 
-See the [runtime docs](./docs/runtime.md) for more details on building your own CLI and join us in the #gluegun channel of the Infinite Red Community Slack ([community.infinite.red](http://community.infinite.red)) to get friendly help!
+See the [runtime docs](runtime.md) for more details on building your own CLI and join us in the #gluegun channel of the Infinite Red Community Slack ([community.infinite.red](http://community.infinite.red)) to get friendly help!
 
 # Who Is Using This?
 


### PR DESCRIPTION
The docs home page has links to "toolbox api docs" and "runtime docs" that result in 404s.

![glue-gun-docs-links](https://user-images.githubusercontent.com/57374/53341292-cc182c00-38d0-11e9-97d3-e478af2529a2.png)

![gluegun-toolbox-bad-link](https://user-images.githubusercontent.com/57374/53341297-ce7a8600-38d0-11e9-985a-890a1deed431.png)

![gluegun-runtime-bad-link](https://user-images.githubusercontent.com/57374/53341305-d1757680-38d0-11e9-8636-498978f4e0d3.png)

Update the links to point to the right location.