### PR TITLE
Add ability to express after, before, delete and replace as regex

### DIFF
--- a/docs/toolbox-patching.md
+++ b/docs/toolbox-patching.md
@@ -30,12 +30,12 @@ If the file ends in `.json`, it'll be read in as an object. Return the updated o
 If the file doesn't end in `.json`, you'll receive a string. Return an updated string to write back to the file.
 
 ```js
-await toolbox.patching.update('config.json', (config) => {
+await toolbox.patching.update('config.json', config => {
   config.key = 'new value'
   return config
 })
 
-await toolbox.patching.update('config.txt', (data) => {
+await toolbox.patching.update('config.txt', data => {
   return data.replace('Jamon', 'Boss')
 })
 ```
@@ -74,7 +74,7 @@ await toolbox.patching.replace('config.txt', 'Remove this string\n', 'Replace wi
 
 > This is an **async** function.
 
-Allows inserting next to, deleting, and replacing strings in a given file. If `insert` is already present in the file, it won't change the file, unless you also pass through `force: true`.
+Allows inserting next to, deleting, and replacing strings or regular expression in a given file. If `insert` is already present in the file, it won't change the file, unless you also pass through `force: true`.
 
 ```js
 await toolbox.patching.patch('config.txt', { insert: 'Jamon', before: 'Something else' })
@@ -82,4 +82,5 @@ await toolbox.patching.patch('config.txt', { insert: 'Jamon', after: 'Something 
 await toolbox.patching.patch('config.txt', { insert: 'Jamon', replace: 'Something else' })
 await toolbox.patching.patch('config.txt', { insert: 'Jamon', replace: 'Something else', force: true })
 await toolbox.patching.patch('config.txt', { delete: 'Something' })
+await toolbox.patching.patch('config.txt', { insert: 'Jamon', after: new RegExp('some regexp') })
 ```

--- a/src/core-extensions/patching-extension.test.ts
+++ b/src/core-extensions/patching-extension.test.ts
@@ -188,3 +188,47 @@ test('patch - deletes text in a text file', async () => {
   const expectedContents = `These are .\n\nThey're very amazing.\n`
   expect(newContents).toBe(expectedContents)
 })
+
+test('patch - able to patch with regex as the value', async () => {
+  const updated = await patching.patch(t.context.textFile, {
+    after: new RegExp('some words'),
+    insert: ' patched info',
+  })
+
+  // returned the updated object
+  expect(updated).toBe(`These are some words patched info.\n\nThey're very amazing.\n`)
+
+  // file was actually written to with the right contents
+  const newContents = await jetpack.read(t.context.textFile, 'utf8')
+  const expectedContents = `These are some words patched info.\n\nThey're very amazing.\n`
+  expect(newContents).toBe(expectedContents)
+})
+
+test('patch - replaces text in a text file with regex as insert value', async () => {
+  const updated = await patching.patch(t.context.textFile, {
+    replace: new RegExp('very amazing'),
+    insert: 'patched info',
+  })
+
+  // returned the updated object
+  expect(updated).toBe(`These are some words.\n\nThey're patched info.\n`)
+
+  // file was actually written to with the right contents
+  const newContents = await jetpack.read(t.context.textFile, 'utf8')
+  const expectedContents = `These are some words.\n\nThey're patched info.\n`
+  expect(newContents).toBe(expectedContents)
+})
+
+test('patch - able to delete text in a text file with regex as delete value', async () => {
+  const updated = await patching.patch(t.context.textFile, {
+    delete: new RegExp('some words'),
+  })
+
+  // returned the updated object
+  expect(updated).toBe(`These are .\n\nThey're very amazing.\n`)
+
+  // file was actually written to with the right contents
+  const newContents = await jetpack.read(t.context.textFile, 'utf8')
+  const expectedContents = `These are .\n\nThey're very amazing.\n`
+  expect(newContents).toBe(expectedContents)
+})

--- a/src/toolbox/patching-types.ts
+++ b/src/toolbox/patching-types.ts
@@ -29,13 +29,13 @@ export interface GluegunPatchingPatchOptions {
   /* String to be inserted */
   insert?: string
   /* Insert before this string */
-  before?: string
+  before?: string | RegExp
   /* Insert after this string */
-  after?: string
+  after?: string | RegExp
   /* Replace this string */
-  replace?: string
+  replace?: string | RegExp
   /* Delete this string */
-  delete?: string
+  delete?: string | RegExp
   /* Write even if it already exists  */
   force?: boolean
 }


### PR DESCRIPTION
With these changes one can use regex for

- before
- after
- delete
- replace

values, giving them extra utility when patching a file.

So for example, can do: 

``` 
  const updated = await patching.patch(t.context.textFile, {
    replace: new RegExp('very amazing'),
    insert: 'patched info',
  })
```