### PR TITLE
Much better Enquirer types

### DIFF
--- a/docs/toolbox-prompt.md
+++ b/docs/toolbox-prompt.md
@@ -97,23 +97,6 @@ module.exports = {
         message: 'Are you sure?',
       },
       {
-        type: 'expand',
-        name: 'exexpand',
-        message: 'What action?',
-        choices: [
-          {
-            key: 'y',
-            name: 'Overwrite',
-            value: 'overwrite',
-          },
-          {
-            key: 'a',
-            name: 'Overwrite this one and all next',
-            value: 'overwrite_all',
-          },
-        ],
-      },
-      {
         type: 'multiselect',
         name: 'exmultiselect',
         message: 'What are your favorite colors?',
@@ -124,6 +107,12 @@ module.exports = {
         name: 'exselect',
         message: 'What is your favorite team?',
         choices: ['Jazz', 'Trail Blazers', 'Lakers', 'Warriors'],
+      },
+      {
+        type: 'multiselect',
+        name: 'exmultiselect',
+        message: 'What are your favorite months?',
+        choices: ['January', 'July', 'September', 'November'],
       },
       {
         type: 'password',
@@ -141,7 +130,7 @@ module.exports = {
         message: 'State?',
         choices: ['Oregon', 'Washington', 'California'],
         // You can leave this off unless you want to customize behavior
-        suggest: (s: string, choices: any[]) => {
+        suggest(s, choices) {
           return choices.filter(choice => {
             return choice.message.toLowerCase().startsWith(s.toLowerCase())
           })

--- a/src/cli/commands/kitchen.ts
+++ b/src/cli/commands/kitchen.ts
@@ -15,12 +15,6 @@ module.exports = {
         choices: ['Clown', 'Other'],
       },
       {
-        type: 'rawlist',
-        name: 'exrawlist',
-        message: 'What nation?',
-        choices: ['Canada', 'United States', 'Mexico'],
-      },
-      {
         type: 'confirm',
         name: 'exconfirm',
         message: 'Are you sure?',
@@ -49,10 +43,16 @@ module.exports = {
         choices: ['red', 'blue', 'yellow'],
       },
       {
-        type: 'radio',
-        name: 'exradio',
+        type: 'select',
+        name: 'exselect',
         message: 'What is your favorite team?',
         choices: ['Jazz', 'Trail Blazers', 'Lakers', 'Warriors'],
+      },
+      {
+        type: 'multiselect',
+        name: 'exmultiselect',
+        message: 'What are your favorite months?',
+        choices: ['January', 'July', 'September', 'November'],
       },
       {
         type: 'password',
@@ -70,7 +70,7 @@ module.exports = {
         message: 'State?',
         choices: ['Oregon', 'Washington', 'California'],
         // You can leave this off unless you want to customize behavior
-        suggest: (s: string, choices: any[]) => {
+        suggest(s, choices) {
           return choices.filter(choice => {
             return choice.message.toLowerCase().startsWith(s.toLowerCase())
           })

--- a/src/cli/commands/new.test.ts
+++ b/src/cli/commands/new.test.ts
@@ -29,7 +29,7 @@ function createFakeToolbox(): Toolbox {
     ask: async () => ({ answer: undefined }),
     confirm: sinon.stub(),
     separator: sinon.stub(),
-  }
+  } as any
   fakeToolbox.template = { generate: sinon.stub() }
   fakeToolbox.print = {
     colors: {

--- a/src/core-extensions/prompt-extension.test.ts
+++ b/src/core-extensions/prompt-extension.test.ts
@@ -35,23 +35,12 @@ test('works as expected', async done => {
     io.send(keys.enter)
     await delay(10)
 
-    // rawlist
-    io.send(keys.down)
-    io.send(keys.down)
-    io.send(keys.enter)
-    await delay(10)
-
     // confirm
     io.send('Y')
-    io.send(keys.enter)
+    // io.send(keys.enter)
     await delay(10)
 
-    // expand
-    io.send('a')
-    io.send(keys.enter)
-    await delay(10)
-
-    // checkbox
+    // multiselect
     io.send(keys.space)
     io.send(keys.down)
     io.send(keys.down)
@@ -59,9 +48,8 @@ test('works as expected', async done => {
     io.send(keys.enter)
     await delay(10)
 
-    // radio
+    // select
     io.send(keys.down)
-    io.send(keys.space)
     io.send(keys.enter)
     await delay(10)
 
@@ -90,42 +78,19 @@ test('works as expected', async done => {
       choices: ['Clown', 'Other'],
     },
     {
-      type: 'rawlist',
-      name: 'exrawlist',
-      message: 'What nation?',
-      choices: ['Canada', 'United States', 'Mexico'],
-    },
-    {
       type: 'confirm',
       name: 'exconfirm',
       message: 'Are you sure?',
     },
     {
-      type: 'expand',
-      name: 'exexpand',
-      message: 'What action?',
-      choices: [
-        {
-          key: 'y',
-          name: 'Overwrite',
-          value: 'overwrite',
-        },
-        {
-          key: 'a',
-          name: 'Overwrite this one and all next',
-          value: 'overwrite_all',
-        },
-      ],
-    },
-    {
-      type: 'checkbox',
-      name: 'excheckbox',
+      type: 'multiselect',
+      name: 'exmultiselect',
       message: 'What are your favorite colors?',
       choices: ['red', 'blue', 'yellow'],
     },
     {
-      type: 'radio',
-      name: 'exradio',
+      type: 'select',
+      name: 'exselect',
       message: 'What is your favorite team?',
       choices: ['Jazz', 'Trail Blazers', 'Lakers', 'Warriors'],
     },
@@ -145,21 +110,17 @@ test('works as expected', async done => {
       message: 'State?',
       choices: ['Oregon', 'Washington', 'California'],
       // You can leave this off unless you want to customize behavior
-      suggest: (s: string, choices: any[]) => {
-        return choices.filter(choice => {
-          return choice.message.toLowerCase().startsWith(s.toLowerCase())
-        })
+      suggest(input, choices) {
+        return choices.filter(choice => choice.message.startsWith(input))
       },
     },
   ])
 
   expect(result).toEqual({
     exlist: 'Other',
-    exrawlist: 'Mexico',
     exconfirm: true,
-    exexpand: 'overwrite_all',
-    excheckbox: ['red', 'yellow'],
-    exradio: 'Trail Blazers',
+    exmultiselect: ['red', 'yellow'],
+    exselect: 'Trail Blazers',
     expassword: 'hunter2',
     exinput: 'Alexander',
     exautocomplete: 'Washington',

--- a/src/toolbox/prompt-enquirer-types.ts
+++ b/src/toolbox/prompt-enquirer-types.ts
@@ -1,0 +1,155 @@
+// imported from https://github.com/enquirer/enquirer/blob/9eef2ed3b4b6222985e4eb85098d3c5a3b2b8b93/index.d.ts
+export interface BasePromptOptions {
+  name: string | (() => string)
+  type: string | (() => string)
+  message: string | (() => string) | (() => Promise<string>)
+  initial?: any
+  required?: boolean
+  format?(value: string): string | Promise<string>
+  result?(value: string): string | Promise<string>
+  skip?: ((state: object) => boolean | Promise<boolean>) | boolean
+  validate?(value: string): boolean | Promise<boolean> | string | Promise<string>
+  onSubmit?(name: string, value: any, prompt: Enquirer.Prompt): boolean | Promise<boolean>
+  onCancel?(name: string, value: any, prompt: Enquirer.Prompt): boolean | Promise<boolean>
+  stdin?: NodeJS.ReadStream
+  stdout?: NodeJS.WriteStream
+}
+
+export interface Choice {
+  name: string
+  message?: string
+  value?: string
+  hint?: string
+  disabled?: boolean | string
+}
+
+export interface ArrayPromptOptions extends BasePromptOptions {
+  type:
+    | 'autocomplete'
+    | 'editable'
+    | 'form'
+    | 'multiselect'
+    | 'select'
+    | 'survey'
+    | 'list'
+    | 'scale'
+    | 'rawlist' // deprecated
+    | 'expand' // deprecated
+    | 'checkbox' // deprecated
+    | 'radio' // deprecated
+    | 'question' // deprecated
+  choices: string[] | Choice[]
+  maxChoices?: number
+  muliple?: boolean
+  initial?: number
+  delay?: number
+  separator?: boolean
+  sort?: boolean
+  linebreak?: boolean
+  edgeLength?: number
+  align?: 'left' | 'right'
+  scroll?: boolean
+  suggest?: (input: string, choices: Choice[]) => Choice[]
+}
+
+export interface BooleanPromptOptions extends BasePromptOptions {
+  type: 'confirm'
+  initial?: boolean
+}
+
+export interface StringPromptOptions extends BasePromptOptions {
+  type: 'input' | 'invisible' | 'list' | 'password' | 'text'
+  initial?: string
+  multiline?: boolean
+}
+
+export interface NumberPromptOptions extends BasePromptOptions {
+  type: 'numeral'
+  min?: number
+  max?: number
+  delay?: number
+  float?: boolean
+  round?: boolean
+  major?: number
+  minor?: number
+  initial?: number
+}
+
+export interface SnippetPromptOptions extends BasePromptOptions {
+  type: 'snippet'
+  newline?: string
+}
+
+export interface SortPromptOptions extends BasePromptOptions {
+  type: 'sort'
+  hint?: string
+  drag?: boolean
+  numbered?: boolean
+}
+
+export type PromptOptions =
+  | ArrayPromptOptions
+  | BooleanPromptOptions
+  | StringPromptOptions
+  | NumberPromptOptions
+  | SnippetPromptOptions
+  | SortPromptOptions
+  | BasePromptOptions
+
+declare class BasePrompt extends NodeJS.EventEmitter {
+  constructor(options?: PromptOptions)
+
+  render(): void
+
+  run(): Promise<any>
+}
+
+declare class Enquirer<T = object> extends NodeJS.EventEmitter {
+  constructor(options?: object, answers?: T)
+
+  /**
+   * Register a custom prompt type.
+   *
+   * @param type
+   * @param fn `Prompt` class, or a function that returns a `Prompt` class.
+   */
+  register(type: string, fn: typeof BasePrompt | (() => typeof BasePrompt)): this
+
+  /**
+   * Register a custom prompt type.
+   */
+  register(type: { [key: string]: typeof BasePrompt | (() => typeof BasePrompt) }): this
+
+  /**
+   * Prompt function that takes a "question" object or array of question objects,
+   * and returns an object with responses from the user.
+   *
+   * @param questions Options objects for one or more prompts to run.
+   */
+  prompt(
+    questions:
+      | PromptOptions
+      | ((this: Enquirer) => PromptOptions)
+      | (PromptOptions | ((this: Enquirer) => PromptOptions))[],
+  ): Promise<T>
+
+  /**
+   * Use an enquirer plugin.
+   *
+   * @param plugin Plugin function that takes an instance of Enquirer.
+   */
+  use(plugin: (this: this, enquirer: this) => void): this
+}
+
+declare namespace Enquirer {
+  function prompt<T = object>(
+    questions:
+      | PromptOptions
+      | ((this: Enquirer) => PromptOptions)
+      | (PromptOptions | ((this: Enquirer) => PromptOptions))[],
+  ): Promise<T>
+
+  class Prompt extends BasePrompt {}
+}
+
+export { Enquirer }

--- a/src/toolbox/prompt-tools.ts
+++ b/src/toolbox/prompt-tools.ts
@@ -1,10 +1,10 @@
-import { GluegunPrompt, GluegunQuestionType, GluegunAskResponse } from './prompt-types'
+import { GluegunEnquirer, GluegunPrompt } from './prompt-types'
 
-let enquirer = null
-function getEnquirer() {
+let enquirer: GluegunEnquirer = null
+function getEnquirer(): GluegunEnquirer {
   if (enquirer) return enquirer
 
-  const Enquirer = require('enquirer')
+  const Enquirer: GluegunEnquirer = require('enquirer')
   enquirer = new Enquirer()
 
   return enquirer
@@ -30,9 +30,9 @@ const confirm = async (message: string): Promise<boolean> => {
  * "lazy load" the package only if and when we actually are asked for it.
  * This results in a significant speed increase.
  */
-const prompt: GluegunPrompt = {
+const prompt = {
   confirm,
-  ask: async (questions: GluegunQuestionType | GluegunQuestionType[]): Promise<GluegunAskResponse> => {
+  ask: async questions => {
     if (Array.isArray(questions)) {
       // Because Enquirer 2 breaks backwards compatility (and we don't want to)
       // we are translating the previous API to the current equivalent.

--- a/src/toolbox/prompt-types.ts
+++ b/src/toolbox/prompt-types.ts
@@ -1,35 +1,26 @@
+import { PromptOptions, Choice } from './prompt-enquirer-types'
+
+const Enquirer = require('enquirer')
+export type GluegunEnquirer = typeof Enquirer
+export const GluegunEnquirer = Enquirer
+
 export interface GluegunPrompt {
   /* Prompts with a confirm message. */
   confirm(message: string): Promise<boolean>
   /* Prompts with a set of questions. */
-  ask(questions: GluegunQuestionType | GluegunQuestionType[]): Promise<GluegunAskResponse>
+  ask<T = object>(
+    questions:
+      | PromptOptions
+      | ((this: GluegunEnquirer) => PromptOptions)
+      | (PromptOptions | ((this: GluegunEnquirer) => PromptOptions))[],
+  ): Promise<T>
   /* Returns a separator. */
   separator(): string
 }
 
-export interface GluegunQuestionChoices {
-  key: string
-  name: string
-  value?: string
-}
+export interface GluegunQuestionChoices extends Choice {}
 
-export interface GluegunQuestionType {
-  type: string
-  name: string
-  message: string
-  // optional
-  suggest?: Function
-  limit?: number
-  highlight?: Function
-  multiple?: boolean
-  choices?: string[] | GluegunQuestionChoices[]
-  default?: string
-  skip?: boolean | Function
-  initial?: string | Function
-  format?: Function
-  result?: Function
-  validate?: Function
-}
+export type GluegunQuestionType = PromptOptions
 
 export interface GluegunAskResponse {
   [key: string]: string

--- a/src/toolbox/prompt-types.ts
+++ b/src/toolbox/prompt-types.ts
@@ -13,7 +13,7 @@ export interface GluegunPrompt {
       | PromptOptions
       | ((this: GluegunEnquirer) => PromptOptions)
       | (PromptOptions | ((this: GluegunEnquirer) => PromptOptions))[],
-  ): Promise<T>
+  ): Promise<GluegunAskResponse>
   /* Returns a separator. */
   separator(): string
 }


### PR DESCRIPTION
I'm now pulling Enquirer types from their own [types file](https://github.com/enquirer/enquirer/blob/9eef2ed3b4b6222985e4eb85098d3c5a3b2b8b93/index.d.ts) (but modifying them to reflect backwards compat).

I plan to release this as a patch-level fix, as it shouldn't break anything. I've tested on Ignite.