### PR TITLE
utils types: Switch `any` to generics 

### DIFF
--- a/src/toolbox/parameter-tools.ts
+++ b/src/toolbox/parameter-tools.ts
@@ -19,6 +19,9 @@ export function parseParams(commandArray: string | string[], extraOpts: Options 
     commandArray = (commandArray as string).split(COMMAND_DELIMITER)
   }
 
+  // we now know it's a string[], so keep TS happy
+  commandArray = commandArray as string[]
+
   // remove the first 2 args if it comes from process.argv
   if (equals(commandArray, process.argv)) {
     commandArray = commandArray.slice(2)

--- a/src/toolbox/utils.ts
+++ b/src/toolbox/utils.ts
@@ -2,26 +2,26 @@
  * Internal tools for use within Gluegun
  */
 
-const head = (a: any[]): any => a[0]
-const tail = (a: any[]): any[] => a.slice(1)
+const head = <T>(a: T[]): T => a[0]
+const tail = <T>(a: T[]): T[] => a.slice(1)
 const identity = a => a
 const isNil = (a: any): boolean => a === null || a === undefined
 const split = (b: string, a: string): string[] => a.split(b)
 const trim = (a: string): string => a.trim()
-const forEach = (f: (i: any) => any, a: any[]) => a.forEach(f)
+const forEach = <T>(f: (i: T) => void, a: T[]) => a.forEach(f)
 const keys = (a: Object): string[] => (Object(a) !== a ? [] : Object.keys(a))
 const replace = (b: string | RegExp, c: string, a: string): string => a.replace(b, c)
-const last = (a: any[]): any => a[a.length - 1]
-const reject = (f: (i: any) => boolean, a: any[]): any[] => a.filter(b => !f(b))
+const last = <T>(a: T[]): T => a[a.length - 1]
+const reject = <T>(f: (i: T) => boolean, a: T[]): T[] => a.filter(b => !f(b))
 const is = (Ctor: any, val: any): boolean => (val != null && val.constructor === Ctor) || val instanceof Ctor
-const takeLast = (n: number, a: any[]): any[] => a.slice(-1 * n)
-const equals = (a, b) => a.length === b.length && a.every((v, i) => v === b[i])
-const times = (fn, n) => {
+const takeLast = <T>(n: number, a: T[]): T[] => a.slice(-1 * n)
+const equals = (a: string[], b: string[]) => a.length === b.length && a.every((v, i) => v === b[i])
+const times = (fn: Function, n: number) => {
   let list = new Array(n)
   for (let i = 0; i < n; i++) list[i] = fn(i)
   return list
 }
-const prop = (p, obj) => obj[p]
+const prop = (p: string, obj: Object) => obj[p]
 
 export {
   head,


### PR DESCRIPTION
Per @sw-yx's tweet, I switched (most of) the utils to generics.

https://twitter.com/swyx/status/1124498943801462789

I think the result isn't as pretty, but it's more useful.