### PR TITLE
It fixes typo in extension example

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -59,7 +59,7 @@ Extensions are additional functionality that you can monkeypatch onto the `toolb
 
 ```js
 // extensions/sayhello.js
-module.exports = function(toolbox) {
+module.exports = (toolbox) => {
   const { print } = toolbox
 
   toolbox.sayhello = () => {

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -59,7 +59,7 @@ Extensions are additional functionality that you can monkeypatch onto the `toolb
 
 ```js
 // extensions/sayhello.js
-module.exports = (toolbox) {
+module.exports = function(toolbox) {
   const { print } = toolbox
 
   toolbox.sayhello = () => {


### PR DESCRIPTION
### Description
It fixes typo in extension example, when i tried to create an extension following the example i got an error. i fix it using `function(toolbox) or toolbox =>`.

before
```js
// extensions/sayhello.js
module.exports = (toolbox) {
  const { print } = toolbox

  toolbox.sayhello = () => {
    print.info('Hello from an extension!')
  }
}
```
after
```js
// extensions/sayhello.js
module.exports = function(toolbox) {
  const { print } = toolbox

  toolbox.sayhello = () => {
    print.info('Hello from an extension!')
  }
}
```
