### PR TITLE
Option to define default value for confirm prompt

### DIFF
--- a/docs/toolbox-prompt.md
+++ b/docs/toolbox-prompt.md
@@ -42,6 +42,7 @@ A pre-built prompt which asks a yes or no question.
 #### parameters
 
 - **message** is a `string` required for displaying a message to user. It's the question you're asking.
+- (optional) **initial** is a `boolean` for setting which answer is the default. `true` for Yes, `false` for No. Defaults to false.
 
 #### returns
 

--- a/src/core-extensions/prompt-extension.test.ts
+++ b/src/core-extensions/prompt-extension.test.ts
@@ -129,3 +129,18 @@ test('works as expected', async done => {
   await delay(2)
   done()
 })
+
+test('Confirm can accept default value', async () => {
+  const toolbox = new Toolbox()
+  createExtension(toolbox)
+  const { prompt } = toolbox
+
+  const sendKeystrokes = async () => {
+    io.send(keys.enter)
+    await delay(10)
+  }
+  setTimeout(() => sendKeystrokes().then(), 5)
+
+  const result = await prompt.confirm('Is default Yes?', true)
+  expect(result).toBeTruthy()
+})

--- a/src/toolbox/prompt-tools.ts
+++ b/src/toolbox/prompt-tools.ts
@@ -16,11 +16,12 @@ function getEnquirer(): GluegunEnquirer {
  * @param message The message to display to the user.
  * @returns The true/false answer.
  */
-const confirm = async (message: string): Promise<boolean> => {
+const confirm = async (message: string, initial?: boolean): Promise<boolean> => {
   const { yesno } = await getEnquirer().prompt({
     name: 'yesno',
     type: 'confirm',
     message,
+    initial,
   })
   return yesno
 }

--- a/src/toolbox/prompt-types.ts
+++ b/src/toolbox/prompt-types.ts
@@ -6,7 +6,7 @@ export const GluegunEnquirer = Enquirer
 
 export interface GluegunPrompt {
   /* Prompts with a confirm message. */
-  confirm(message: string): Promise<boolean>
+  confirm(message: string, initial?: boolean): Promise<boolean>
   /* Prompts with a set of questions. */
   ask<T = object>(
     questions:


### PR DESCRIPTION
Confirm had "no" as the default value, it would be nice to be able to set it yourself. This PR does that. No breaking change, just option to define it.