### PR TITLE
Toolbox config prop should be required

### DIFF
--- a/src/domain/toolbox.ts
+++ b/src/domain/toolbox.ts
@@ -50,8 +50,8 @@ export interface GluegunEmptyToolbox {
 // Final toolbox
 export interface GluegunToolbox extends GluegunEmptyToolbox {
   // known properties
+  config: Options
   result?: any
-  config?: Options
   parameters: GluegunParameters
   plugin?: Plugin
   command?: Command
@@ -75,8 +75,9 @@ export interface GluegunToolbox extends GluegunEmptyToolbox {
 
 export class EmptyToolbox implements GluegunEmptyToolbox {
   [x: string]: any
+  public config: Options & { loadConfig?: (name: string, src: string) => Options } = {}
+
   public result?: any = null
-  public config?: Options & { loadConfig?: (name: string, src: string) => Options } = {}
   public parameters?: GluegunParameters = { options: {} }
   public plugin?: Plugin = null
   public command?: Command = null


### PR DESCRIPTION
While working on Ignite, I noticed that the `GluegunToolbox#config` property is marked optional when it should be required. This PR fixes that.

I for some reason changed it in [this commit](https://github.com/infinitered/gluegun/commit/15c4258bf91acc396d396a91e36c442bd9127330).