### PR TITLE
Boilerplate TypeScript CLIs now properly copy templates folder

### DIFF
--- a/src/cli/templates/cli/.gitignore.ejs
+++ b/src/cli/templates/cli/.gitignore.ejs
@@ -5,3 +5,4 @@ coverage
 .nyc_output
 dist
 build
+.vscode

--- a/src/cli/templates/cli/package.json.ejs
+++ b/src/cli/templates/cli/package.json.ejs
@@ -10,8 +10,10 @@
     <% if (props.typescript) { %>
       "format": "prettier --write **/*.{js,ts,tsx,json}",
       "lint": "tslint -p .",
+      "clean-build": "rm -rf ./build",
       "compile": "tsc -p .",
-      "build": "yarn format && yarn lint && yarn compile",
+      "copy-templates": "if [ -e ./src/templates ]; then cp -a ./src/templates ./build/; fi",
+      "build": "yarn format && yarn lint && yarn clean-build && yarn compile && yarn copy-templates",
     <% } else { %>
       "format": "prettier --write **/*.{js,json} && standard --fix",
       "lint": "standard",


### PR DESCRIPTION
Fixes #509. Ref https://github.com/snowfrogdev/Vts/pull/2.