### PR TITLE
fix(#393): generic was unused set ask response as default

### DIFF
--- a/src/toolbox/prompt-types.ts
+++ b/src/toolbox/prompt-types.ts
@@ -4,16 +4,20 @@ const Enquirer = require('enquirer')
 export type GluegunEnquirer = typeof Enquirer
 export const GluegunEnquirer = Enquirer
 
+export interface GluegunAskResponse {
+  [key: string]: string
+}
+
 export interface GluegunPrompt {
   /* Prompts with a confirm message. */
   confirm(message: string, initial?: boolean): Promise<boolean>
   /* Prompts with a set of questions. */
-  ask<T = object>(
+  ask<T = GluegunAskResponse>(
     questions:
       | PromptOptions
       | ((this: GluegunEnquirer) => PromptOptions)
       | (PromptOptions | ((this: GluegunEnquirer) => PromptOptions))[],
-  ): Promise<GluegunAskResponse>
+  ): Promise<T>
   /* Returns a separator. */
   separator(): string
 }
@@ -21,7 +25,3 @@ export interface GluegunPrompt {
 export interface GluegunQuestionChoices extends Choice {}
 
 export type GluegunQuestionType = PromptOptions
-
-export interface GluegunAskResponse {
-  [key: string]: string
-}


### PR DESCRIPTION
While creating a prompt to generate react components for a workflow tool. I ran into an issue where I couldn't easily tell the prompt what my expected return object would look like.

My work around was to use:
```
as any
```
However I realized that the generic T was not being refrenced so I set AskResponse as the default and made the Promise generic.

**Before**
```
const options = await prompt.ask(questions);
```
Options would be considered to be GluegunAskResponse which of course is expected
```
const options = await prompt.ask<MyResponse>(questions);
```
In this case we would still be given GluegunAskResponse which is NOT expected.

**After**
```
const options = await prompt.ask(questions);
```
Now options will default to GluegunAskResponse.
```
const options = await prompt.ask<MyResponse>(questions);
```
And this time be the correct type.