### PR TITLE
fix(toolbox): `run` command potential fall through when rejecting

### DIFF
--- a/src/toolbox/system-tools.test.ts
+++ b/src/toolbox/system-tools.test.ts
@@ -17,5 +17,5 @@ test('run - should reject if the command does not exist', async () => {
 
 test('run - should resolve if the command exists', async () => {
   // `echo` should be a general command for both *nix and windows
-  await expect(system.run('echo "gluegun"', { trim: true })).resolves.toBe('gluegun')
+  await expect(system.run('echo gluegun', { trim: true })).resolves.toBe('gluegun')
 })

--- a/src/toolbox/system-tools.test.ts
+++ b/src/toolbox/system-tools.test.ts
@@ -10,3 +10,11 @@ test('which - non-existing package', () => {
   const result = system.which('non-existing-package')
   expect(result).toBe(null)
 })
+
+test('run - should reject if the command does not exist', async () => {
+  await expect(system.run('non-existing-command')).rejects.toThrowError()
+})
+
+test('run - should resolve if the command exists', async () => {
+  await expect(system.run('pwd', { trim: true })).resolves.toBe(process.cwd())
+})

--- a/src/toolbox/system-tools.test.ts
+++ b/src/toolbox/system-tools.test.ts
@@ -16,5 +16,6 @@ test('run - should reject if the command does not exist', async () => {
 })
 
 test('run - should resolve if the command exists', async () => {
-  await expect(system.run('pwd', { trim: true })).resolves.toBe(process.cwd())
+  // `echo` should be a general command for both *nix and windows
+  await expect(system.run('echo "gluegun"', { trim: true })).resolves.toBe('gluegun')
 })

--- a/src/toolbox/system-tools.ts
+++ b/src/toolbox/system-tools.ts
@@ -1,5 +1,5 @@
 import { Options } from '../domain/options'
-import { GluegunSystem } from './system-types'
+import { GluegunSystem, GluegunError, StringOrBuffer } from './system-types'
 import { head, tail, isNil } from './utils'
 
 /**
@@ -15,10 +15,10 @@ async function run(commandLine: string, options: Options = {}): Promise<any> {
 
   return new Promise((resolve, reject) => {
     const { exec } = require('child_process')
-    exec(commandLine, nodeOptions, (error: any, stdout: string, stderr: string) => {
+    exec(commandLine, nodeOptions, (error: GluegunError, stdout: StringOrBuffer, stderr: StringOrBuffer) => {
       if (error) {
         error.stderr = stderr
-        reject(error)
+        return reject(error)
       }
       resolve(trimmer(stdout || ''))
     })

--- a/src/toolbox/system-types.ts
+++ b/src/toolbox/system-types.ts
@@ -4,7 +4,7 @@ export interface GluegunSystem {
    */
   exec(command: string, options?: any): Promise<any>
   /**
-   * Runs a commmand and returns stdout as a trimmed string.
+   * Runs a command and returns stdout as a trimmed string.
    */
   run(command: string, options?: any): Promise<string>
   /**
@@ -27,3 +27,9 @@ export interface GluegunSystem {
  * Returns the number of milliseconds from when the timer started.
  */
 export type GluegunTimer = () => number
+
+export type StringOrBuffer = string | Buffer
+
+export interface GluegunError extends Error {
+  stderr?: StringOrBuffer
+}


### PR DESCRIPTION
* Promise `resolve` will no longer be called when the `system.run()`
method rejects
* Strengthened types for `system.run` slightly
* Added basic tests for `system.run`