### PR TITLE
fix(cli): templates can now have includes (#570)

### DIFF
--- a/src/toolbox/template-tools.ts
+++ b/src/toolbox/template-tools.ts
@@ -38,6 +38,9 @@ function buildGenerate(toolbox: GluegunToolbox): (opts: Options) => Promise<stri
     const directory = opts.directory ? opts.directory : `${plugin && plugin.directory}/templates`
 
     const pathToTemplate = `${directory}/${template}`
+    
+    // add template path to support includes
+    data.filename = pathToTemplate
 
     // bomb if the template doesn't exist
     if (!filesystem.isFile(pathToTemplate)) {


### PR DESCRIPTION
When an include was made inside an .ejs template, an error would occur.

The fix for the problem was to pass a filename property with the template path to the ejs.render().

Close #570.