### PR TITLE
fix(cli): templates can now have includes (#570)

### DIFF
--- a/src/cli/templates/test/helloMessage.ejs
+++ b/src/cli/templates/test/helloMessage.ejs
@@ -1,0 +1,1 @@
+'Hello. I am a chatty plugin.'

--- a/src/cli/templates/test/kitchen-sink-command.js.ejs
+++ b/src/cli/templates/test/kitchen-sink-command.js.ejs
@@ -52,7 +52,7 @@ module.exports = {
     asyncs.push(apiDirect.get('/repos/skellock/apisauce/commits'))
 
     // print smoke test
-    print.info(print.colors.success('Hello. I am a chatty plugin.'))
+    print.info(print.colors.success(<%- include helloMessage %>))
     print.spin('Time for fun!').stop()
     print.printHelp(toolbox)
     print.table(

--- a/src/toolbox/template-tools.ts
+++ b/src/toolbox/template-tools.ts
@@ -27,6 +27,7 @@ function buildGenerate(toolbox: GluegunToolbox): (opts: Options) => Promise<stri
       config: toolbox && toolbox.config,
       parameters: toolbox && toolbox.parameters,
       props,
+      filename: '',
     }
 
     // add our string tools to the filters available.
@@ -38,6 +39,9 @@ function buildGenerate(toolbox: GluegunToolbox): (opts: Options) => Promise<stri
     const directory = opts.directory ? opts.directory : `${plugin && plugin.directory}/templates`
 
     const pathToTemplate = `${directory}/${template}`
+
+    // add template path to support includes
+    data.filename = pathToTemplate
 
     // bomb if the template doesn't exist
     if (!filesystem.isFile(pathToTemplate)) {


### PR DESCRIPTION
When an include was made inside an .ejs template, an error would occur.

The fix for the problem was to pass a filename property with the template path to the ejs.render().

Close #570.