### PR TITLE
`fancy` can support any type of message not just strings

### DIFF
--- a/src/toolbox/print-tools.ts
+++ b/src/toolbox/print-tools.ts
@@ -121,7 +121,7 @@ function table(data: string[][], options: any = {}): void {
  *
  * @param message The message to write.
  */
-function fancy(message: string): void {
+function fancy(message: any): void {
   console.log(message)
 }
 


### PR DESCRIPTION
`console.log` can handle logging out any type of data, so no reason to limit to just strings