### PR TITLE
use 'colors/safe' import

### DIFF
--- a/src/toolbox/print-tools.ts
+++ b/src/toolbox/print-tools.ts
@@ -1,5 +1,5 @@
 import * as CLITable from 'cli-table3'
-import * as importedColors from 'colors'
+import * as importedColors from 'colors/safe'
 import { commandInfo } from './meta-tools'
 import { Toolbox } from '../domain/toolbox'
 import { times } from './utils'


### PR DESCRIPTION
This should give some improved startup performance by using `colors/safe` instead of `colors` as part of #363 .

I did some small performance tests before and after. I used the solidarity CLI tool importing gluegun as a local dependency with both the `colors` and `colors/safe` import. I modified the index file of solidarity to add a performance test to measure startup time. The code for this test was almost line for line copied from [this page](https://nodejs.org/api/perf_hooks.html#perf_hooks_performance_timing_api). For each run of the test the following command was used in the solidarity src `yarn run start help`. Results below.


Run | `import * as importedColors from 'colors'` |`import * as importedColors from 'colors/safe'`
-- | -- | --
1 | 744.354061 | 922.968393
2 | 780.787561 | 785.511972
3 | 806.319184 | 838.51216
4 | 848.683204 | 809.270677
5 | 774.831334 | 737.21025
6 | 846.565335 | 732.862413
7 | 758.77335 | 706.699215
8 | 857.815747 | 726.877857
9 | 855.347242 | 795.518162
10 | 830.887427 | 736.544598
11 | 945.266739 | 800.813298
12 | 791.227134 | 723.008018
13 | 820.485336 | 756.052169
14 | 799.518046 | 797.387063
15 | 833.48273 | 804.818274
16 | 762.411512 | 791.334877
17 | 722.501943 | 818.663465
18 | 844.012722 | 825.011324
19 | 708.766262 | 758.761023
20 | 831.388846 | 798.058164
Average | 808.17128575 | 783.2941686

If there's a better way or a standard way to test this instead just let me know and ill be happy to do it.