### PR TITLE
add commented-out .exclude method to cli.js.es

### DIFF
--- a/src/cli/templates/cli/src/cli.js.ejs
+++ b/src/cli/templates/cli/src/cli.js.ejs
@@ -12,8 +12,10 @@ async function run(argv) {
     .help() // provides default for help, h, --help, -h
     .version() // provides default for version, v, --version, -v
     .create()
-
-  // and run it
+    // enable the following method if you'd like to skip loading one of these core extensions
+    // this can improve performance if they're not necessary for your project: 
+    // .exclude(['meta', 'strings', 'print', 'filesystem', 'semver', 'system', 'prompt', 'http', 'template', 'patching'])
+    // and run it
   const toolbox = await cli.run(argv)
 
   // send it back (for testing, mostly)


### PR DESCRIPTION
Addresses #362 

It looks like the .brand has been updated, but the .exclude method has been added to the CLI template. 