### PR TITLE
Add yarn build as a prePublish step to the CLI default package.json

### DIFF
--- a/src/cli/templates/cli/package.json.ejs
+++ b/src/cli/templates/cli/package.json.ejs
@@ -17,6 +17,7 @@
       "compile": "tsc -p .",
       "copy-templates": "if [ -e ./src/templates ]; then cp -a ./src/templates ./build/; fi",
       "build": "yarn format && yarn lint && yarn clean-build && yarn compile && yarn copy-templates",
+      "prepublishOnly": "yarn build",
     <% } else { %>
       "format": "prettier --write **/*.{js,json} && standard --fix",
       "lint": "standard",


### PR DESCRIPTION
then you don't have to remember