### PR TITLE
Move typescript definition back in the default CLI example command

### DIFF
--- a/src/cli/templates/cli/src/commands/default.js.ejs
+++ b/src/cli/templates/cli/src/commands/default.js.ejs
@@ -1,12 +1,14 @@
 <% if (props.language === "typescript") { %>
-import { GluegunToolbox } from 'gluegun'
+import { GluegunCommand } from 'gluegun'
 <% } %>
 
-module.exports = {
+const command<%= (props.language === "typescript") ? ": GluegunCommand" : "" %> = {
   name: '<%= props.name %>',
-  run: async <%= (props.language === "typescript") ? "(toolbox: GluegunToolbox)" : "toolbox" %> => {
+  run: async toolbox => {
     const { print } = toolbox
 
     print.info('Welcome to your CLI')
   },
 }
+
+module.exports = command


### PR DESCRIPTION
currently it's only typing the `run` function, but now it types the entire command and you get  `run` typed for free