### PR TITLE
Allows commands, extensions, and templates to be nested in a build folder

### DIFF
--- a/docs/guide-architecture.md
+++ b/docs/guide-architecture.md
@@ -77,6 +77,8 @@ commands
     world.js
 ```
 
+As of Gluegun 4.1.0, you can also nest commands in a `build` folder, if for example you're using TypeScript and want to compile to `./build`.
+
 ## Extensions
 
 Think of extensions as "drawers" full of tools in your Gluegun toolbox. In the above example, the `hello` extension adds two functions, `greetEarthling` and `greetAlien`.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -8,6 +8,8 @@ A plugin is directory that contains 3 optional sub-directories:
 - `templates`
 - `extensions`
 
+(You can also nest these three directories in `build`, for a build pipeline, and Gluegun will still find them. Requires Gluegun 4.1.0+.)
+
 And 1 optional file, which can be `<brand>.config.js`, `.<brand>rc.json`, or `.<brand>rc.yaml`. Replace `<brand>` with the name of your CLI.
 
 Other than the 3 directories listed, you're welcome to put any other files or sub-directories in the plugin directory. For example, we include a `plugin.js` file in the root of plugins for [Ignite CLI](https://github.com/infinitered/ignite) to help us load it effectively.
@@ -59,7 +61,7 @@ Extensions are additional functionality that you can monkeypatch onto the `toolb
 
 ```js
 // extensions/sayhello.js
-module.exports = (toolbox) => {
+module.exports = toolbox => {
   const { print } = toolbox
 
   toolbox.sayhello = () => {

--- a/docs/tutorial-making-a-plugin.md
+++ b/docs/tutorial-making-a-plugin.md
@@ -36,7 +36,7 @@ $ yarn init
 
 At this point, go through yarn's init. It doesn't matter too much what you put here. I just hit enter on everything.
 
-Lastly, add a `commands` and an `extensions` folder.
+Lastly, add a `commands` and an `extensions` folder. Note that with new versions of Gluegun, you can also use a build pipeline and include your commands and extensions in `build/commands` and `build/extensions` and Gluegun will still find them.
 
 ```bash
 $ mkdir commands extensions

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "eslint-config-prettier": "6.4.0",
     "eslint-config-standard": "14.1.0",
     "eslint-plugin-import": "2.18.2",
+    "eslint-plugin-jest": "^22.20.0",
     "eslint-plugin-node": "10.0.0",
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-standard": "4.0.1",
@@ -144,11 +145,13 @@
       "sourceType": "module"
     },
     "plugins": [
-      "@typescript-eslint"
+      "@typescript-eslint",
+      "jest"
     ],
     "env": {
       "node": true,
-      "es6": true
+      "es6": true,
+      "jest/globals": true
     },
     "extends": [
       "eslint:recommended",

--- a/src/core-extensions/template-extension.test.ts
+++ b/src/core-extensions/template-extension.test.ts
@@ -7,6 +7,7 @@ const createRuntime = () => {
   const r = new Runtime()
   r.addCoreExtensions()
   r.addPlugin(`${__dirname}/../fixtures/good-plugins/generate`)
+  r.addPlugin(`${__dirname}/../fixtures/good-plugins/generate-build`)
   return r
 }
 
@@ -36,6 +37,38 @@ test('detects missing templates', async () => {
 
 test('supports directories', async () => {
   const toolbox = await createRuntime().run('special location')
+
+  expect(toolbox.result).toBe('location' + os.EOL)
+})
+
+// Test in a build folder
+
+test('generates a simple file in a build folder', async () => {
+  const toolbox = await createRuntime().run('build simple')
+
+  expect(toolbox.result).toBe('simple file' + os.EOL)
+})
+
+test('supports props in a build folder', async () => {
+  const toolbox = await createRuntime().run('build props Greetings_and_salutations', {
+    stars: 5,
+  })
+
+  expect(toolbox.result).toBe(
+    `greetingsAndSalutations world${os.EOL}` + `red${os.EOL}green${os.EOL}blue${os.EOL}*****${os.EOL}`,
+  )
+})
+
+test('detects missing templates in a build folder', async () => {
+  try {
+    await createRuntime().run('build missing')
+  } catch (e) {
+    expect(startsWith('template not found', e.message)).toBe(true)
+  }
+})
+
+test('supports directories in a build folder', async () => {
+  const toolbox = await createRuntime().run('build special location')
 
   expect(toolbox.result).toBe('location' + os.EOL)
 })

--- a/src/domain/builder.test.ts
+++ b/src/domain/builder.test.ts
@@ -21,8 +21,8 @@ test('the gauntlet', () => {
   expect(runtime).toBeTruthy()
 
   expect(runtime.brand).toBe('test')
-  expect(runtime.commands.length).toBe(26)
-  expect(runtime.extensions.length).toBe(14)
+  expect(runtime.commands.length).toBe(34)
+  expect(runtime.extensions.length).toBe(15)
   expect(runtime.defaultPlugin.commands.length).toBe(6)
 
   const { commands } = runtime.defaultPlugin
@@ -35,5 +35,5 @@ test('the gauntlet', () => {
   expect(commands[5].name).toBe('gimmedatversion')
   expect(commands[5].run(new Toolbox())).toBe('it works')
 
-  expect(runtime.plugins.length).toBe(16)
+  expect(runtime.plugins.length).toBe(18)
 })

--- a/src/fixtures/good-plugins/generate-build/build/commands/build/missing.js
+++ b/src/fixtures/good-plugins/generate-build/build/commands/build/missing.js
@@ -1,0 +1,12 @@
+const uniqueTempDir = require('unique-temp-dir')
+
+async function missing(toolbox) {
+  const template = 'missing.ejs'
+  const dir = uniqueTempDir({ create: true })
+  const target = `${dir}/missing.txt`
+
+  const result = await toolbox.template.generate({ template, target })
+  return result
+}
+
+module.exports = { name: 'missing', run: missing }

--- a/src/fixtures/good-plugins/generate-build/build/commands/build/props.js
+++ b/src/fixtures/good-plugins/generate-build/build/commands/build/props.js
@@ -1,0 +1,15 @@
+const uniqueTempDir = require('unique-temp-dir')
+
+async function command(toolbox) {
+  const template = 'props.ejs'
+  const dir = uniqueTempDir({ create: true })
+  const target = `${dir}/props.txt`
+  const props = {
+    thing: 'world',
+    colors: ['red', 'green', 'blue'],
+  }
+
+  return toolbox.template.generate({ template, target, props })
+}
+
+module.exports = { name: 'props', run: command }

--- a/src/fixtures/good-plugins/generate-build/build/commands/build/simple.js
+++ b/src/fixtures/good-plugins/generate-build/build/commands/build/simple.js
@@ -1,0 +1,12 @@
+const uniqueTempDir = require('unique-temp-dir')
+
+async function simple(toolbox) {
+  const template = 'simple.ejs'
+  const dir = uniqueTempDir({ create: true })
+  const target = `${dir}/simple.txt`
+
+  const result = await toolbox.template.generate({ template, target })
+  return result
+}
+
+module.exports = { name: 'simple', run: simple }

--- a/src/fixtures/good-plugins/generate-build/build/commands/build/special.js
+++ b/src/fixtures/good-plugins/generate-build/build/commands/build/special.js
@@ -1,0 +1,13 @@
+const uniqueTempDir = require('unique-temp-dir')
+
+async function command(toolbox) {
+  const template = 'special.ejs'
+  const dir = uniqueTempDir({ create: true })
+  const target = `${dir}/special.txt`
+  const props = { thing: toolbox.parameters.first }
+  const directory = `${__dirname}/../../custom-directory`
+
+  return toolbox.template.generate({ template, target, props, directory })
+}
+
+module.exports = { name: 'special', run: command }

--- a/src/fixtures/good-plugins/generate-build/build/custom-directory/special.ejs
+++ b/src/fixtures/good-plugins/generate-build/build/custom-directory/special.ejs
@@ -1,0 +1,1 @@
+<%= props.thing %>

--- a/src/fixtures/good-plugins/generate-build/build/templates/props.ejs
+++ b/src/fixtures/good-plugins/generate-build/build/templates/props.ejs
@@ -1,0 +1,5 @@
+<%= camelCase(parameters.first) %> <%= props.thing %>
+<%_ props.colors.forEach(function(color) { _%>
+<%= color %>
+<%_ }) _%>
+*****

--- a/src/fixtures/good-plugins/generate-build/build/templates/simple.ejs
+++ b/src/fixtures/good-plugins/generate-build/build/templates/simple.ejs
@@ -1,0 +1,1 @@
+simple file

--- a/src/fixtures/good-plugins/generate-build/gluegun.toml
+++ b/src/fixtures/good-plugins/generate-build/gluegun.toml
@@ -1,0 +1,8 @@
+name = 'generate'
+
+[[commands]]
+description = 'Generates a simple file'
+
+[[commands]]
+description = 'Replaces props in a template.'
+

--- a/src/fixtures/good-plugins/nested-build/build/commands/implied/bar.js
+++ b/src/fixtures/good-plugins/nested-build/build/commands/implied/bar.js
@@ -1,0 +1,3 @@
+module.exports = {
+  run: () => 'implied',
+}

--- a/src/fixtures/good-plugins/nested-build/build/commands/nested.js
+++ b/src/fixtures/good-plugins/nested-build/build/commands/nested.js
@@ -1,0 +1,4 @@
+module.exports = {
+  name: 'nested',
+  run: () => {},
+}

--- a/src/fixtures/good-plugins/nested-build/build/commands/thing/foo.js
+++ b/src/fixtures/good-plugins/nested-build/build/commands/thing/foo.js
@@ -1,0 +1,5 @@
+module.exports = {
+  name: 'foo',
+  alias: 'f',
+  run: toolbox => `nested thing foo in build folder has run with ${toolbox.nestedBuild}`,
+}

--- a/src/fixtures/good-plugins/nested-build/build/commands/thing/thing.js
+++ b/src/fixtures/good-plugins/nested-build/build/commands/thing/thing.js
@@ -1,0 +1,5 @@
+module.exports = {
+  name: 'thing',
+  alias: 't',
+  run: () => {},
+}

--- a/src/fixtures/good-plugins/nested-build/build/extensions/nested-build-extension.js
+++ b/src/fixtures/good-plugins/nested-build/build/extensions/nested-build-extension.js
@@ -1,0 +1,3 @@
+module.exports = toolbox => {
+  toolbox.nestedBuild = "loaded extension"
+}

--- a/src/loaders/plugin-loader.ts
+++ b/src/loaders/plugin-loader.ts
@@ -49,22 +49,28 @@ export function loadPluginFromDirectory(directory: string, options: Options = {}
   plugin.commands = (options.preloadedCommands || []).map(loadCommandFromPreload)
 
   // load the commands found in the commands sub-directory
-  if (jetpackPlugin.exists('commands') === 'dir') {
-    const commands = jetpackPlugin.cwd('commands').find({ matching: commandFilePattern, recursive: true })
+  const commandSearchDirectories = ['commands', 'build/commands']
+  commandSearchDirectories.map(dir => {
+    if (jetpackPlugin.exists(dir) === 'dir') {
+      const commands = jetpackPlugin.cwd(dir).find({ matching: commandFilePattern, recursive: true })
 
-    plugin.commands = plugin.commands.concat(
-      commands.map(file => loadCommandFromFile(path.join(directory, 'commands', file))),
-    )
-  }
+      plugin.commands = plugin.commands.concat(
+        commands.map(file => loadCommandFromFile(path.join(directory, dir, file))),
+      )
+    }
+  })
 
   // load the extensions found in the extensions sub-directory
-  if (jetpackPlugin.exists('extensions') === 'dir') {
-    const extensions = jetpackPlugin.cwd('extensions').find({ matching: extensionFilePattern, recursive: false })
+  const extensionSearchDirectories = ['extensions', 'build/extensions']
+  extensionSearchDirectories.map(dir => {
+    if (jetpackPlugin.exists(dir) === 'dir') {
+      const extensions = jetpackPlugin.cwd(dir).find({ matching: extensionFilePattern, recursive: false })
 
-    plugin.extensions = extensions.map(file => loadExtensionFromFile(`${directory}/extensions/${file}`))
-  } else {
-    plugin.extensions = []
-  }
+      plugin.extensions = plugin.extensions.concat(
+        extensions.map(file => loadExtensionFromFile(`${directory}/${dir}/${file}`)),
+      )
+    }
+  })
 
   // load config using cosmiconfig
   const config = loadConfig(plugin.name, directory)

--- a/src/runtime/runtime-plugins.test.ts
+++ b/src/runtime/runtime-plugins.test.ts
@@ -6,7 +6,7 @@ test('loads all sub-directories', () => {
   r.addCoreExtensions()
   r.addPlugins(`${__dirname}/../fixtures/good-plugins`)
 
-  expect(14).toBe(r.plugins.length)
+  expect(16).toBe(r.plugins.length)
 })
 
 test('matches sub-directories', () => {

--- a/src/runtime/runtime-run-good.test.ts
+++ b/src/runtime/runtime-run-good.test.ts
@@ -30,6 +30,17 @@ test('runs a nested command', async () => {
   expect(toolbox.result).toBe('nested thing foo has run')
 })
 
+test('runs a nested command in build folder', async () => {
+  const r = new Runtime()
+  r.addCoreExtensions()
+  r.addPlugin(`${__dirname}/../fixtures/good-plugins/nested-build`)
+  const toolbox = await r.run('thing foo')
+  expect(toolbox.command).toBeTruthy()
+  expect(toolbox.command.name).toBe('foo')
+  expect(toolbox.command.commandPath).toEqual(['thing', 'foo'])
+  expect(toolbox.result).toBe('nested thing foo in build folder has run with loaded extension')
+})
+
 test('runs a command with no name prop', async () => {
   const r = new Runtime()
   r.addCoreExtensions()

--- a/tslint.json
+++ b/tslint.json
@@ -1,9 +1,0 @@
-{
-  "extends": ["tslint-config-standard", "tslint-config-prettier"],
-  "rules": {
-    "strict-type-predicates": false
-  },
-  "linterOptions": {
-    "exclude": ["src/cli/templates/**/*.js.ejs", "src/cli/templates/**/*.js.ejs.ejs"]
-  }
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -694,6 +694,15 @@
     "@typescript-eslint/typescript-estree" "2.4.0"
     eslint-scope "^5.0.0"
 
+"@typescript-eslint/experimental-utils@^1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz#b08c60d780c0067de2fb44b04b432f540138301e"
+  integrity sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "1.13.0"
+    eslint-scope "^4.0.0"
+
 "@typescript-eslint/parser@2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.4.0.tgz#fe43ed5fec14af03d3594fce2c3b7ec4c8df0243"
@@ -703,6 +712,14 @@
     "@typescript-eslint/experimental-utils" "2.4.0"
     "@typescript-eslint/typescript-estree" "2.4.0"
     eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/typescript-estree@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz#8140f17d0f60c03619798f1d628b8434913dc32e"
+  integrity sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.5.0"
 
 "@typescript-eslint/typescript-estree@2.4.0":
   version "2.4.0"
@@ -2391,6 +2408,13 @@ eslint-plugin-import@2.18.2:
     read-pkg-up "^2.0.0"
     resolve "^1.11.0"
 
+eslint-plugin-jest@^22.20.0:
+  version "22.20.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.20.0.tgz#a3c3615c516fcbd20d50dbf395ea37361bd9e3b2"
+  integrity sha512-UwHGXaYprxwd84Wer8H7jZS+5C3LeEaU8VD7NqORY6NmPJrs+9Ugbq3wyjqO3vWtSsDaLar2sqEB8COmOZA4zw==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^1.13.0"
+
 eslint-plugin-node@10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz#fd1adbc7a300cf7eb6ac55cf4b0b6fc6e577f5a6"
@@ -2412,6 +2436,14 @@ eslint-plugin-standard@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz#ff0519f7ffaff114f76d1bd7c3996eef0f6e20b4"
   integrity sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==
+
+eslint-scope@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
+  integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
 
 eslint-scope@^5.0.0:
   version "5.0.0"
@@ -7032,6 +7064,11 @@ semver-regex@^2.0.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
+semver@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+  integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
 
 semver@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
In TypeScript-enabled plugins, it's a common thing to have a `./build` folder with your build artifacts, which for a Gluegun plugin would include commands, extensions, and templates.

This enables Gluegun to search in a `build` folder if it doesn't find commands, extensions, or templates in the root of a plugin, and makes it easier to have plugins be TypeScript (or other languages) with a `./build` target folder.

I considered making it configurable, but none of the options really seemed all that attractive. Since `./build` is pretty common, I'm just hard-coding that.