### PR TITLE
Makes toolbox patch function able to receive multiple options

### DIFF
--- a/docs/toolbox-patching.md
+++ b/docs/toolbox-patching.md
@@ -83,4 +83,9 @@ await toolbox.patching.patch('config.txt', { insert: 'Jamon', replace: 'Somethin
 await toolbox.patching.patch('config.txt', { insert: 'Jamon', replace: 'Something else', force: true })
 await toolbox.patching.patch('config.txt', { delete: 'Something' })
 await toolbox.patching.patch('config.txt', { insert: 'Jamon', after: new RegExp('some regexp') })
+await toolbox.patching.patch(
+  'config.txt',
+  { insert: 'Jamon', after: 'Something else' },
+  { insert: 'Jamon', before: 'Something else' },
+)
 ```

--- a/src/core-extensions/patching-extension.test.ts
+++ b/src/core-extensions/patching-extension.test.ts
@@ -232,6 +232,7 @@ test('patch - able to delete text in a text file with regex as delete value', as
   const expectedContents = `These are .\n\nThey're very amazing.\n`
   expect(newContents).toBe(expectedContents)
 })
+
 test('patch - able to execute multiple file operations', async () => {
   const updated = await patching.patch(
     t.context.textFile,
@@ -250,5 +251,52 @@ test('patch - able to execute multiple file operations', async () => {
   // file was actually written to with the right contents
   const newContents = await jetpack.read(t.context.textFile, 'utf8')
   const expectedContents = `These are .\n\nThey're patched info.\n`
+  expect(newContents).toBe(expectedContents)
+})
+
+test('patch - do not make changes that already have been done', async () => {
+  const updated = await patching.patch(
+    t.context.textFile,
+    {
+      before: 'some words',
+      insert: 'These are ',
+    },
+    {
+      after: "They're ",
+      insert: 'very amazing.',
+    },
+  )
+
+  // returned the updated object
+  expect(updated).toBeFalsy()
+
+  // file was actually written to with the right contents
+  const newContents = await jetpack.read(t.context.textFile, 'utf8')
+  const expectedContents = `These are some words.\n\nThey're very amazing.\n`
+  expect(newContents).toBe(expectedContents)
+})
+
+test('patch - able to make partial changes', async () => {
+  const updated = await patching.patch(
+    t.context.textFile,
+    {
+      before: 'some words',
+      insert: 'These are ',
+    },
+    {
+      delete: new RegExp('some words'),
+    },
+    {
+      after: "They're ",
+      insert: 'very amazing.',
+    },
+  )
+
+  // returned the updated object
+  expect(updated).toBe(`These are .\n\nThey're very amazing.\n`)
+
+  // file was actually written to with the right contents
+  const newContents = await jetpack.read(t.context.textFile, 'utf8')
+  const expectedContents = `These are .\n\nThey're very amazing.\n`
   expect(newContents).toBe(expectedContents)
 })

--- a/src/core-extensions/patching-extension.test.ts
+++ b/src/core-extensions/patching-extension.test.ts
@@ -232,3 +232,23 @@ test('patch - able to delete text in a text file with regex as delete value', as
   const expectedContents = `These are .\n\nThey're very amazing.\n`
   expect(newContents).toBe(expectedContents)
 })
+test('patch - able to execute multiple file operations', async () => {
+  const updated = await patching.patch(
+    t.context.textFile,
+    {
+      delete: new RegExp('some words'),
+    },
+    {
+      replace: new RegExp('very amazing'),
+      insert: 'patched info',
+    },
+  )
+
+  // returned the updated object
+  expect(updated).toBe(`These are .\n\nThey're patched info.\n`)
+
+  // file was actually written to with the right contents
+  const newContents = await jetpack.read(t.context.textFile, 'utf8')
+  const expectedContents = `These are .\n\nThey're patched info.\n`
+  expect(newContents).toBe(expectedContents)
+})

--- a/src/toolbox/patching-tools.ts
+++ b/src/toolbox/patching-tools.ts
@@ -99,8 +99,8 @@ export async function replace(filename: string, oldContent: string, newContent: 
  *   await toolbox.patching.patch('thing.js', { before: 'bar', insert: 'foo' })
  *
  */
-export async function patch(filename: string, opts: GluegunPatchingPatchOptions = {}): Promise<string | false> {
-  return update(filename, data => patchString(data as string, opts)) as Promise<string | false>
+export async function patch(filename: string, ...opts: GluegunPatchingPatchOptions[]): Promise<string | false> {
+  return update(filename, (data: string) => opts.reduce(patchString, data)) as Promise<string | false>
 }
 
 export async function readFile(filename: string): Promise<string> {

--- a/src/toolbox/patching-tools.ts
+++ b/src/toolbox/patching-tools.ts
@@ -100,7 +100,14 @@ export async function replace(filename: string, oldContent: string, newContent: 
  *
  */
 export async function patch(filename: string, ...opts: GluegunPatchingPatchOptions[]): Promise<string | false> {
-  return update(filename, (data: string) => opts.reduce(patchString, data)) as Promise<string | false>
+  return update(filename, (data: string) => {
+    const result = opts.reduce(
+      (updatedData: string, opt: GluegunPatchingPatchOptions) => patchString(updatedData, opt) || updatedData,
+      data,
+    )
+
+    return result !== data && result
+  }) as Promise<string | false>
 }
 
 export async function readFile(filename: string): Promise<string> {

--- a/src/toolbox/patching-types.ts
+++ b/src/toolbox/patching-types.ts
@@ -22,7 +22,7 @@ export interface GluegunPatching {
   /**
    * Makes a patch inside file.
    */
-  patch(filename: string, options: GluegunPatchingPatchOptions): Promise<string | boolean>
+  patch(filename: string, ...options: GluegunPatchingPatchOptions[]): Promise<string | boolean>
 }
 
 export interface GluegunPatchingPatchOptions {


### PR DESCRIPTION
This allows to make multiple changes in a file at once with only one file access using `toolbox.patching.patch` function. Example:

```javascript
const updated = await toolbox.patching.patch(
  textFile,
    {
      delete: 'some words',
    },
    {
      replace: 'very amazing',
      insert: 'patched info',
    }
)
```