### PR TITLE
fix(cli): remove leading space in ES import

### DIFF
--- a/src/cli/templates/cli/src/commands/generate.js.ejs
+++ b/src/cli/templates/cli/src/commands/generate.js.ejs
@@ -1,5 +1,5 @@
 <% if (props.language === "typescript") { %>
-  import { GluegunToolbox } from 'gluegun'
+import { GluegunToolbox } from 'gluegun'
 <% } %>  
 
 module.exports = {


### PR DESCRIPTION
Before
```typescript
  import { GluegunToolbox } from 'gluegun'

module.exports = {
```

After
```typescript
import { GluegunToolbox } from 'gluegun'

module.exports = {
```