### PR TITLE
fix(types): stronger typing for print table method. Sync up data param

### DIFF
--- a/src/toolbox/print-tools.ts
+++ b/src/toolbox/print-tools.ts
@@ -3,7 +3,7 @@ import * as importedColors from 'colors/safe'
 import { commandInfo } from './meta-tools'
 import { Toolbox } from '../domain/toolbox'
 import { times } from './utils'
-import { GluegunPrint, GluegunPrintColors } from './print-types'
+import { GluegunPrint, GluegunPrintColors, GluegunPrintTableOptions } from './print-types'
 
 // We're extending `colors` with a few more attributes
 const colors = importedColors as GluegunPrintColors
@@ -88,7 +88,7 @@ function columnHeaderDivider(cliTable: CLITable): string[] {
  *
  * @param object The object to turn into a table.
  */
-function table(data: string[][], options: any = {}): void {
+function table(data: string[][], options: GluegunPrintTableOptions = {}): void {
   let t
   switch (options.format) {
     case 'markdown':
@@ -165,7 +165,7 @@ function warning(message: string): void {
  *
  * @param message The message to show.
  */
-function debug(message: string, title: string = 'DEBUG'): void {
+function debug(message: string, title = 'DEBUG'): void {
   const topLine = `vvv -----[ ${title} ]----- vvv`
   const botLine = `^^^ -----[ ${title} ]----- ^^^`
 

--- a/src/toolbox/print-types.ts
+++ b/src/toolbox/print-types.ts
@@ -1,8 +1,8 @@
 import { GluegunToolbox } from '../index'
 import * as CLITable from 'cli-table3'
 import * as importedColors from 'colors'
-import ora = require('ora')
 import { Toolbox } from '../domain/toolbox'
+import ora = require('ora')
 
 export type GluegunPrintColors = typeof importedColors & {
   highlight: (t: string) => string
@@ -12,6 +12,10 @@ export type GluegunPrintColors = typeof importedColors & {
   error: (t: string) => string
   line: (t: string) => string
   muted: (t: string) => string
+}
+
+export interface GluegunPrintTableOptions {
+  format?: 'markdown' | 'lean' | 'default'
 }
 
 export interface GluegunPrint {
@@ -42,7 +46,7 @@ export interface GluegunPrint {
   /* Prints a newline. */
   newline: () => void
   /* Prints a table of data (usually a 2-dimensional array). */
-  table: (data: any, options?: any) => void
+  table: (data: string[][], options?: GluegunPrintTableOptions) => void
   /* An `ora`-powered spinner. */
   spin(options?: ora.Options | string): ora.Ora
   /* Print help info for known CLI commands. */


### PR DESCRIPTION
- Added `GluegunPrintTableOptions` interface to create a stronger typing for the `print.table` method.
- Updated the `GluegunPrint` interface so the `table` has the same signature as in the `print-tools.ts` file.
- Line 168: removed `string` typing;
  - Type string trivially inferred from a string literal, remove type annotation.eslint@typescript-eslint/no-inferrable-types