### PR TITLE
Update new template

### DIFF
--- a/package-manager.js
+++ b/package-manager.js
@@ -1,0 +1,1 @@
+module.exports = require('./build/package-manager')

--- a/src/cli/commands/new.ts
+++ b/src/cli/commands/new.ts
@@ -110,12 +110,12 @@ const NewCommand: GluegunCommand = {
       'package.json.ejs',
       'readme.md.ejs',
       '.gitignore.ejs',
+      '.eslintrc.js.ejs',
     ]
 
     if (props.language === 'typescript') {
       files.push('src/types.js.ejs')
       files.push('tsconfig.json.ejs')
-      files.push('tslint.json.ejs') // TODO: swap out TSlint for ESlint in generated CLIs
     }
 
     // rename js files to ts
@@ -124,7 +124,7 @@ const NewCommand: GluegunCommand = {
 
       const target =
         `${props.name}/` +
-        (props.language === 'typescript' && file.includes('.js.ejs')
+        (props.language === 'typescript' && file.includes('.js.ejs') && !file.startsWith('.')
           ? file.replace('.js.ejs', '.ts')
           : file.replace('.ejs', ''))
 

--- a/src/cli/templates/cli/.eslintrc.js.ejs
+++ b/src/cli/templates/cli/.eslintrc.js.ejs
@@ -1,0 +1,20 @@
+/**
+ * @type {import("eslint").Linter.Config}
+ */
+module.exports = {
+  <% if (props.language === "typescript") { %>
+    parser: '@typescript-eslint/parser',
+  <% } %>
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module'
+  },
+  extends: [
+  <% if (props.language === "typescript") { %>
+    'plugin:@typescript-eslint/recommended',
+  <% } %>
+    'prettier',
+    'plugin:prettier/recommended'
+  ],
+  rules: {}
+}

--- a/src/cli/templates/cli/__tests__/cli-integration.test.js.ejs
+++ b/src/cli/templates/cli/__tests__/cli-integration.test.js.ejs
@@ -1,4 +1,8 @@
-const { system, filesystem } = require('gluegun')
+<% if (props.language === "typescript") { %>
+  import { system, filesystem } from 'gluegun'
+<% } else { %>
+  const { system, filesystem } = require('gluegun')
+<% } %>
 
 const src = filesystem.path(__dirname, '..')
 

--- a/src/cli/templates/cli/package.json.ejs
+++ b/src/cli/templates/cli/package.json.ejs
@@ -43,25 +43,21 @@
   "devDependencies": {
     <% if (props.language === "typescript") { %>
       "@types/node": "^12.7.11",
-      "@types/jest": "^24.0.18",
+      "@types/jest": "^26.0.20",
       "@typescript-eslint/eslint-plugin": "^4.17.0",
       "@typescript-eslint/parser": "^4.17.0",
       "ts-node": "^8.4.1",
-      "ts-jest": "^24.1.0",
       "typescript": "^3.6.3",
     <% } %>
     "eslint": "^7.22.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^3.3.1",
     "husky": "^5.1.3",
-    "jest": "^24.1.0",
+    "jest": "^26.6.3",
     "prettier": "^2.2.1",
     "pretty-quick": "^3.1.0"
   },
   "jest": {
-    <% if (props.language === "typescript") { %>
-      "preset": "ts-jest",
-    <% } %>
     "testEnvironment": "node"
   },
   "prettier": {

--- a/src/cli/templates/cli/package.json.ejs
+++ b/src/cli/templates/cli/package.json.ejs
@@ -13,7 +13,7 @@
     <% if (props.language === "typescript") { %>
       "clean-build": "rm -rf ./build",
       "compile": "tsc -p .",
-      "copy-templates": "if [ -e ./src/templates ]; then cp -a ./src/templates ./build/; fi",
+      "copy-templates": "copyfiles ./src/templates/* ./build/templates",
       "build": "yarn clean-build && yarn compile && yarn copy-templates",
       "prepublishOnly": "yarn build",
       "format": "eslint **/*.{js,jsx,ts,tsx} --fix && prettier **/*.{js,jsx,ts,tsx,json} --write",
@@ -50,6 +50,7 @@
       "ts-node": "^9.1.1",
       "typescript": "^4.2.3",
     <% } %>
+    "copyfiles": "^2.4.1",
     "eslint": "^7.22.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^3.3.1",

--- a/src/cli/templates/cli/package.json.ejs
+++ b/src/cli/templates/cli/package.json.ejs
@@ -11,16 +11,14 @@
   },
   "scripts": {
     <% if (props.language === "typescript") { %>
-      "format": "prettier --write **/*.{js,ts,tsx,json}",
-      "lint": "tslint -p .",
       "clean-build": "rm -rf ./build",
       "compile": "tsc -p .",
       "copy-templates": "if [ -e ./src/templates ]; then cp -a ./src/templates ./build/; fi",
-      "build": "yarn format && yarn lint && yarn clean-build && yarn compile && yarn copy-templates",
+      "build": "yarn clean-build && yarn compile && yarn copy-templates",
       "prepublishOnly": "yarn build",
+      "format": "eslint **/*.{js,jsx,ts,tsx} --fix && prettier **/*.{js,jsx,ts,tsx,json} --write",
     <% } else { %>
-      "format": "prettier --write **/*.{js,json} && standard --fix",
-      "lint": "standard",
+      "format": "eslint **/*.{js,jsx} --fix && prettier **/*.{js,jsx,json} --write",
     <% } %>
     "test": "jest",
     "watch": "jest --watch",
@@ -29,8 +27,6 @@
   },
   "files": [
     <% if (props.language === "typescript") { %>
-      "tsconfig.json",
-      "tslint.json",
       "build",
     <% } else { %>
       "src",
@@ -48,17 +44,19 @@
     <% if (props.language === "typescript") { %>
       "@types/node": "^12.7.11",
       "@types/jest": "^24.0.18",
+      "@typescript-eslint/eslint-plugin": "^4.17.0",
+      "@typescript-eslint/parser": "^4.17.0",
       "ts-node": "^8.4.1",
       "ts-jest": "^24.1.0",
-      "tslint": "^5.12.0",
-      "tslint-config-prettier": "^1.17.0",
-      "tslint-config-standard": "^8.0.1",
       "typescript": "^3.6.3",
-    <% } else { %>
-      "standard": "^12.0.1",
     <% } %>
-    "prettier": "^1.12.1",
-    "jest": "^24.1.0"
+    "eslint": "^7.22.0",
+    "eslint-config-prettier": "^8.1.0",
+    "eslint-plugin-prettier": "^3.3.1",
+    "husky": "^5.1.3",
+    "jest": "^24.1.0",
+    "prettier": "^2.2.1",
+    "pretty-quick": "^3.1.0"
   },
   "jest": {
     <% if (props.language === "typescript") { %>
@@ -66,15 +64,13 @@
     <% } %>
     "testEnvironment": "node"
   },
-  <% if (props.language === "javascript") { %>
-  "standard": {
-    "env": [
-      "jest"
-    ]
-  },
-  <% } %>
   "prettier": {
     "semi": false,
     "singleQuote": true
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
   }
 }

--- a/src/cli/templates/cli/package.json.ejs
+++ b/src/cli/templates/cli/package.json.ejs
@@ -46,6 +46,7 @@
       "@types/jest": "^26.0.20",
       "@typescript-eslint/eslint-plugin": "^4.17.0",
       "@typescript-eslint/parser": "^4.17.0",
+      "ts-jest": "^26.5.3",
       "ts-node": "^9.1.1",
       "typescript": "^4.2.3",
     <% } %>
@@ -58,6 +59,9 @@
     "pretty-quick": "^3.1.0"
   },
   "jest": {
+    <% if (props.language === "typescript") { %>
+      "preset": "ts-jest",
+    <% } %>
     "testEnvironment": "node"
   },
   "prettier": {

--- a/src/cli/templates/cli/package.json.ejs
+++ b/src/cli/templates/cli/package.json.ejs
@@ -46,8 +46,8 @@
       "@types/jest": "^26.0.20",
       "@typescript-eslint/eslint-plugin": "^4.17.0",
       "@typescript-eslint/parser": "^4.17.0",
-      "ts-node": "^8.4.1",
-      "typescript": "^3.6.3",
+      "ts-node": "^9.1.1",
+      "typescript": "^4.2.3",
     <% } %>
     "eslint": "^7.22.0",
     "eslint-config-prettier": "^8.1.0",

--- a/src/cli/templates/cli/package.json.ejs
+++ b/src/cli/templates/cli/package.json.ejs
@@ -16,9 +16,9 @@
       "copy-templates": "copyfiles ./src/templates/* ./build/templates",
       "build": "yarn clean-build && yarn compile && yarn copy-templates",
       "prepublishOnly": "yarn build",
-      "format": "eslint **/*.{js,jsx,ts,tsx} --fix && prettier **/*.{js,jsx,ts,tsx,json} --write",
+      "format": "eslint \"**/*.{js,jsx,ts,tsx}\" --fix && prettier \"**/*.{js,jsx,ts,tsx,json}\" --write",
     <% } else { %>
-      "format": "eslint **/*.{js,jsx} --fix && prettier **/*.{js,jsx,json} --write",
+      "format": "eslint \"**/*.{js,jsx}\" --fix && prettier \"**/*.{js,jsx,json}\" --write",
     <% } %>
     "test": "jest",
     "watch": "jest --watch",

--- a/src/cli/templates/cli/readme.md.ejs
+++ b/src/cli/templates/cli/readme.md.ejs
@@ -13,9 +13,10 @@ To package your CLI up for NPM, do this:
 ```shell
 $ npm login
 $ npm whoami
-$ npm lint
 $ npm test
-(if typescript, run `npm run build` here)
+<% if (props.language === "typescript") { %>
+$ npm run build
+<% } %>
 $ npm publish
 ```
 

--- a/src/cli/templates/cli/src/cli.js.ejs
+++ b/src/cli/templates/cli/src/cli.js.ejs
@@ -1,4 +1,8 @@
-const { build } = require('gluegun')
+<% if (props.language === "typescript") { %>
+  import { build } from 'gluegun'
+<% } else { %>
+  const { build } = require('gluegun')  
+<% } %>
 
 /**
  * Create the cli and kick it off

--- a/src/cli/templates/cli/tslint.json.ejs
+++ b/src/cli/templates/cli/tslint.json.ejs
@@ -1,9 +1,0 @@
-{
-  "extends": ["tslint-config-standard", "tslint-config-prettier"],
-  "rules": {
-    "strict-type-predicates": false
-  },
-  "env": {
-    "jest": true
-  }
-}


### PR DESCRIPTION
fixes #737

Hello,

First of all, very nice project, this looks really amazing and I can't wait to try this framework on my projects 😁 

This said, the `new` template looks a bit out-of-date, so this is my little contribution to this project

### What's inside?

1. Bump the main dependencies (jest, typescript, ts-node, …)
2. Use `copyfiles` to be able to build the project on a windows machine
3. Migrate ts-lint to eslint
4. Add `husky` & `pretty-quick` to format on pre-commit
5. Use `import` instead of `require` on typescript project (so eslint is happy)

### How to test

* Generate a javascript project with `gluegun new` and run `yarn test`
* Generate a typescript project with `gluegun new` and run `yarn test` / `yarn build`