### PR TITLE
feat(print): add style options for tables

### DIFF
--- a/docs/toolbox-print.md
+++ b/docs/toolbox-print.md
@@ -193,3 +193,38 @@ Output:
 | Steve      | Kellock   | 43  |
 | Gary       | Busey     | 73  |
 ```
+
+You can also pass styles for the table (as specified in [cli-table3](https://github.com/cli-table/cli-table3)):
+
+```js
+const { table } = toolbox.print
+table(
+  [
+    ['First Name', 'Last Name', 'Age'],
+    ['Jamon', 'Holmgren', 35],
+    ['Gant', 'Laborde', 36],
+    ['Steve', 'Kellock', 43],
+    ['Gary', 'Busey', 73],
+  ],
+  {
+    format: 'lean',
+    style: { 'padding-left': 0 , 'padding-right': 8 }
+  },
+)
+```
+
+Output:
+
+```
+┌──────────────────┬─────────────────┬───────────┐
+│First Name        │Last Name        │Age        │
+├──────────────────┼─────────────────┼───────────┤
+│Jamon             │Holmgren         │35         │
+├──────────────────┼─────────────────┼───────────┤
+│Gant              │Laborde          │36         │
+├──────────────────┼─────────────────┼───────────┤
+│Steve             │Kellock          │43         │
+├──────────────────┼─────────────────┼───────────┤
+│Gary              │Busey            │73         │
+└──────────────────┴─────────────────┴───────────┘
+```

--- a/src/toolbox/__snapshots__/print-tools.test.ts.snap
+++ b/src/toolbox/__snapshots__/print-tools.test.ts.snap
@@ -73,5 +73,18 @@ Array [
 | matthew | 2 |",
     undefined,
   ],
+  Array [
+    "| liam        | 5     |
+| ----------- | ----- |
+| matthew     | 2     |",
+    undefined,
+  ],
+  Array [
+    "┌─────────┬───┐
+│ liam    │ 5 │
+│ matthew │ 2 │
+└─────────┴───┘",
+    undefined,
+  ],
 ]
 `;

--- a/src/toolbox/print-tools.test.ts
+++ b/src/toolbox/print-tools.test.ts
@@ -36,6 +36,20 @@ test('info', () => {
     ],
     { format: 'markdown' },
   )
+  print.table(
+    [
+      ['liam', '5'],
+      ['matthew', '2'],
+    ],
+    { format: 'markdown', style: { 'padding-left': 1, 'padding-right': 3 } },
+  )
+  print.table(
+    [
+      ['liam', '5'],
+      ['matthew', '2'],
+    ],
+    { format: 'lean', style: { compact: true } },
+  )
 
   expect(spyLogger).toMatchSnapshot()
 })

--- a/src/toolbox/print-types.ts
+++ b/src/toolbox/print-types.ts
@@ -14,8 +14,11 @@ export type GluegunPrintColors = typeof importedColors & {
   muted: (t: string) => string
 }
 
+export type TableStyle = Partial<CLITable.TableInstanceOptions['style']>
+
 export interface GluegunPrintTableOptions {
   format?: 'markdown' | 'lean' | 'default'
+  style?: TableStyle
 }
 
 export interface GluegunPrint {
@@ -46,7 +49,7 @@ export interface GluegunPrint {
   /* Finds the column widths for a table */
   findWidths: (cliTable: CLITable) => number[]
   /* Returns column header dividers for a table */
-  columnHeaderDivider: (cliTable: CLITable) => string[]
+  columnHeaderDivider: (cliTable: CLITable, style: TableStyle) => string[]
   /* Prints a newline. */
   newline: () => void
   /* Prints a table of data (usually a 2-dimensional array). */


### PR DESCRIPTION
This adds the ability to pass a `style` property on `print.table`'s options, as requested on #724 (although it still doesn't fully achieve what the issue's author wanted).

* Created new type `TableStyle`
* Added style prop on `GluegunPrintTableOptions`
* Modified markdown table formatting to correctly print columns header dividers when padding is applied
* Updated tests and docs accordingly