### PR TITLE
Remove ramda/ramdasauce from gluegun

### DIFF
--- a/docs/toolbox-api.md
+++ b/docs/toolbox-api.md
@@ -25,7 +25,7 @@ Here's what's available inside the `toolbox` object you see all over Gluegun.
 | **print**          | tools to print output to the command line          | colors, ora                    |
 | **prompt**         | tools to acquire extra command line user input     | enquirer                       |
 | **semver**         | utilities for working with semantic versioning     | semver                         |
-| **strings**        | some string helpers like case conversion, etc.     | lodash & ramda                 |
+| **strings**        | some string helpers like case conversion, etc.     | lodash                         |
 | **system**         | ability to execute                                 | node-which, execa, cross-spawn |
 | **template**       | code generation from templates                     | ejs                            |
 | **packageManager** | ability to add or remove packages with Yarn/NPM    |                                |

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "lodash.upperfirst": "^4.3.1",
     "ora": "^4.0.0",
     "pluralize": "^8.0.0",
-    "ramdasauce": "^2.1.0",
     "semver": "^7.0.0",
     "which": "^2.0.0",
     "yargs-parser": "^16.1.0"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "apisauce": "^2.1.4",
+    "apisauce": "^2.1.5",
     "app-module-path": "^2.2.0",
     "cli-table3": "~0.5.0",
     "colors": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "apisauce": "^2.0.1",
+    "apisauce": "^2.1.4",
     "app-module-path": "^2.2.0",
     "cli-table3": "~0.5.0",
     "colors": "^1.3.3",

--- a/src/core-extensions/template-extension.test.ts
+++ b/src/core-extensions/template-extension.test.ts
@@ -62,7 +62,7 @@ test('detects missing templates in a build folder', async () => {
   try {
     await createRuntime().run('build missing')
   } catch (e) {
-    expect(startsWith('template not found', e.message)).toBe(true)
+    expect(e.message).toContain('template not found')
   }
 })
 

--- a/src/core-extensions/template-extension.test.ts
+++ b/src/core-extensions/template-extension.test.ts
@@ -1,6 +1,5 @@
 import * as os from 'os'
 import * as expect from 'expect'
-import { startsWith } from 'ramdasauce'
 import { Runtime } from '../runtime/runtime'
 
 const createRuntime = () => {
@@ -31,7 +30,7 @@ test('detects missing templates', async () => {
   try {
     await createRuntime().run('missing')
   } catch (e) {
-    expect(startsWith('template not found', e.message)).toBe(true)
+    expect(e.message).toContain('template not found')
   }
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,13 +937,12 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-apisauce@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/apisauce/-/apisauce-2.0.1.tgz#cf5af56ea6ff5145e6eeb8d4ba471c7e0662b8c4"
-  integrity sha512-mJBw3pKmtfVoP6oifnf7/iRJQtNkVb6GkYsVOXN2pidootj1mhGBtzYHOX9FVBzAz5QV2GMu8IJtiNIgZ44kHQ==
+apisauce@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/apisauce/-/apisauce-2.1.4.tgz#c7854da1a0114a1a381ee7d4a5d817adad48c464"
+  integrity sha512-nGVIArky1zTTCcfEsRcd/M90TzSrRdRVQGW8TCYkRHc/rOE3AWBoSYcKfrNDy8zQ1Yiol5E9uM8xHjls5L5+Zw==
   dependencies:
-    axios "^0.21.1"
-    ramda "^0.25.0"
+    axios "^0.21.4"
 
 app-module-path@^2.2.0:
   version "2.2.0"
@@ -1135,12 +1134,12 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@^0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
-  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+axios@^0.21.4:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
-    follow-redirects "^1.10.0"
+    follow-redirects "^1.14.0"
 
 babel-jest@^24.9.0:
   version "24.9.0"
@@ -2918,10 +2917,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.10.0:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.2.tgz#dd73c8effc12728ba5cf4259d760ea5fb83e3147"
-  integrity sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
+follow-redirects@^1.14.0:
+  version "1.14.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.6.tgz#8cfb281bbc035b3c067d6cd975b0f6ade6e855cd"
+  integrity sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -6589,11 +6588,6 @@ qw@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/qw/-/qw-1.0.1.tgz#efbfdc740f9ad054304426acb183412cc8b996d4"
   integrity sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=
-
-ramda@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
-  integrity sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==
 
 rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
   version "1.2.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6590,22 +6590,10 @@ qw@~1.0.1:
   resolved "https://registry.yarnpkg.com/qw/-/qw-1.0.1.tgz#efbfdc740f9ad054304426acb183412cc8b996d4"
   integrity sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=
 
-ramda@^0.24.1:
-  version "0.24.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
-  integrity sha1-w7d1UZfzW43DUCIoJixMkd22uFc=
-
 ramda@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
   integrity sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==
-
-ramdasauce@^2.1.0:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/ramdasauce/-/ramdasauce-2.1.3.tgz#acb45ecc7e4fc4d6f39e19989b4a16dff383e9c2"
-  integrity sha512-Ml3CPim4SKwmg5g9UI77lnRSeKr/kQw7YhQ6rfdMcBYy6DMlwmkEwQqjygJ3OhxPR+NfFfpjKl3Tf8GXckaqqg==
-  dependencies:
-    ramda "^0.24.1"
 
 rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
   version "1.2.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,10 +937,10 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-apisauce@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/apisauce/-/apisauce-2.1.4.tgz#c7854da1a0114a1a381ee7d4a5d817adad48c464"
-  integrity sha512-nGVIArky1zTTCcfEsRcd/M90TzSrRdRVQGW8TCYkRHc/rOE3AWBoSYcKfrNDy8zQ1Yiol5E9uM8xHjls5L5+Zw==
+apisauce@^2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/apisauce/-/apisauce-2.1.5.tgz#546229f8f145711b3b022065afb0f43bd304ecb3"
+  integrity sha512-bkMlz0ZUnyS8vDigej9UBYo5dne9/bQrkgIiIkGaiDHF6e5OxhYRLJDYu65V/Ox86tmWVwepIntAoTmk4Db0Hg==
   dependencies:
     axios "^0.21.4"
 


### PR DESCRIPTION
In an effort to rid our code bases of all traces of [ramda](https://github.com/ramda/ramda), I'm slowly de-ramdaifying.

This removes ramda.js from Gluegun.