### PR TITLE
fix(deps): Pin colors to 1.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "apisauce": "^2.1.5",
     "app-module-path": "^2.2.0",
     "cli-table3": "~0.5.0",
-    "colors": "^1.3.3",
+    "colors": "1.3.3",
     "cosmiconfig": "6.0.0",
     "cross-spawn": "^7.0.0",
     "ejs": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1658,7 +1658,12 @@ colors@1.0.3:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
-colors@^1.1.2, colors@^1.3.3:
+colors@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
+  integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
+
+colors@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==


### PR DESCRIPTION
Fixes: https://github.com/infinitered/gluegun/issues/744

By the way I've ran the tests locally and they passed. I guess here they failed because I'm not a contributor, and CI doesn't run for security reasons (so non-contributors can't manipulate env vars).

```
otaviopace@Otavios-MacBook-Pro ~/gluegun (fix/pin-colors-dependency)> npm test

> gluegun@4.7.1 test /Users/otaviopace/gluegun
> jest

 PASS  src/toolbox/string-tools.test.ts
 PASS  src/loaders/module-loader.test.ts
✔ What shoes are you wearing? · Other

✔ What shoes are you wearing? · Other
✔ Are you sure? (y/N) · true
✔ What are your favorite colors? · red, yellow


✔ What are your favorite colors? · red, yellow


✔ What are your favorite colors? · red, yellow

✔ What are your favorite colors? · red, yellow
✔ What is your favorite team? · Trail Blazers



✔ What is your favorite team? · Trail Blazers
✔ Enter a fake password · *******
 PASS  src/core-extensions/prompt-extension.test.ts (5.169s)
✔ What is your middle name? · Alexander
✔ State? · Washington


✔ State? · Washington


✔ State? · Washington


✔ State? · Washington

✔ State? · Washington
✔ Is default Yes? (Y/n) · true
 PASS  src/cli/commands/new.test.ts (5.196s)
 PASS  src/core-extensions/patching-extension.test.ts (5.499s)
 PASS  src/loaders/plugin-loader.test.ts (5.52s)
 PASS  src/toolbox/package-manager.test.ts
 PASS  src/loaders/command-loader.test.ts
 PASS  src/toolbox/meta-tools.test.ts
 PASS  src/runtime/runtime-parameters.test.ts (7.736s)
 PASS  src/runtime/runtime-run-good.test.ts
 PASS  src/index.test.ts
 PASS  src/core-extensions/template-extension.test.ts
 PASS  src/toolbox/print-tools.test.ts
 PASS  src/core-extensions/system-extension.test.ts
 PASS  src/loaders/extension-loader.test.ts
 PASS  src/toolbox/filesystem-tools.test.ts
 PASS  src/core-extensions/print-extension.test.ts
 PASS  src/core-extensions/http-extension.test.ts
 PASS  src/runtime/runtime-plugins.test.ts
 PASS  src/domain/builder.test.ts
 PASS  src/core-extensions/filesystem-extension.test.ts
 PASS  src/runtime/runtime-src.test.ts
 PASS  src/runtime/runtime-config.test.ts
 PASS  src/runtime/runtime-extensions.test.ts
 PASS  src/toolbox/system-tools.test.ts
 PASS  src/runtime/runtime-plugin.test.ts
 PASS  src/domain/command.test.ts
 PASS  src/core-extensions/meta-extension.test.ts
 PASS  src/domain/plugin.test.ts
 PASS  src/runtime/runtime-run-bad.test.ts
 PASS  src/core-extensions/strings-extension.test.ts
 PASS  src/domain/toolbox.test.ts

Test Suites: 33 passed, 33 total
Tests:       189 passed, 189 total
Snapshots:   1 passed, 1 total
Time:        9.755s
Ran all test suites.
```