### PR TITLE
fix(deps): Upgrade yargs-parser - fixes #725

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@
 defaults: &defaults
   docker:
     # Choose the version of Node you want here
-    - image: circleci/node:10.18
+    - image: circleci/node:16.13
   working_directory: ~/repo
 
 version: 2

--- a/package-manager.js
+++ b/package-manager.js
@@ -1,0 +1,1 @@
+module.exports = require('./build/package-manager')

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "pluralize": "^8.0.0",
     "semver": "^7.0.0",
     "which": "^2.0.0",
-    "yargs-parser": "^16.1.0"
+    "yargs-parser": "^21.0.0"
   },
   "devDependencies": {
     "@semantic-release/git": "9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8493,6 +8493,11 @@ yargs-parser@^16.1.0:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.0.tgz#a485d3966be4317426dd56bdb6a30131b281dc55"
+  integrity sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==
+
 yargs-parser@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"


### PR DESCRIPTION
fixes #725 -- yargs-parser has a vulnerability.

Given that this will potentially change the behavior of gluegun-powered CLIs, this will probably need to be a breaking change.