### PR TITLE
Add onAbort function to toolbox meta

### DIFF
--- a/docs/toolbox-meta.md
+++ b/docs/toolbox-meta.md
@@ -46,3 +46,13 @@ Retrieves information about all of this CLI's commands. You can use this to disp
 const commandInfo = toolbox.meta.commandInfo()
 toolbox.print.table(commandInfo)
 ```
+
+## onAbort
+
+Executes the given callback when a [termination signal](https://nodejs.org/api/process.html#process_signal_events) is received. These signals are `SIGINT`, `SIGQUIT`, `SIGTERM`, `SIGHUP`, `SIGBREAK`. If callback returns a promise, it will wait for promise to resolve before aborting.
+
+```js
+toolbox.meta.onAbort((signal) => {
+  console.log('Received termination signal', signal)
+})
+```

--- a/src/cli/commands/new.test.ts
+++ b/src/cli/commands/new.test.ts
@@ -17,6 +17,7 @@ function createFakeToolbox(): Toolbox {
     packageJSON: sinon.stub(),
     checkForUpdate: sinon.stub(),
     commandInfo: sinon.stub(),
+    onAbort: sinon.stub(),
   }
   fakeToolbox.filesystem = {
     resolve: sinon.stub(),

--- a/src/core-extensions/meta-extension.ts
+++ b/src/core-extensions/meta-extension.ts
@@ -1,4 +1,4 @@
-import { commandInfo, getVersion, checkForUpdate, getPackageJSON } from '../toolbox/meta-tools'
+import { commandInfo, getVersion, checkForUpdate, getPackageJSON, onAbort } from '../toolbox/meta-tools'
 import { GluegunToolbox } from '../domain/toolbox'
 import { PackageJSON } from '../toolbox/meta-types'
 
@@ -8,6 +8,7 @@ export interface GluegunMeta {
   packageJSON: () => PackageJSON
   commandInfo: () => string[][]
   checkForUpdate: () => Promise<boolean | string>
+  onAbort: typeof onAbort
 }
 
 /**
@@ -22,6 +23,7 @@ export default function attach(toolbox: GluegunToolbox): void {
     packageJSON: () => getPackageJSON(toolbox),
     commandInfo: () => commandInfo(toolbox),
     checkForUpdate: () => checkForUpdate(toolbox),
+    onAbort,
   }
   toolbox.meta = meta
 }

--- a/src/toolbox/meta-types.ts
+++ b/src/toolbox/meta-types.ts
@@ -35,3 +35,5 @@ export interface PackageJSON {
 
   [k: string]: any
 }
+
+export type AbortSignals = 'SIGINT' | 'SIGQUIT' | 'SIGTERM' | 'SIGHUP' | 'SIGBREAK'


### PR DESCRIPTION
In my project I'm working with temporary files and needed this solution. And since there's an issue about it, I wanted to open a PR. (This is my first open-source PR, I'm sorry if there's an issue about it.)

I've never worked with signals before, let me know if I have a mistake that needs to be resolved.
I've used the signals described in [node.js](https://nodejs.org/api/process.html#process_signal_events) and [GNU](https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html) documentation.

![onAbort preview](https://user-images.githubusercontent.com/86152092/152460666-953e0317-fff5-495c-aa9c-a89509786631.gif)

Fixes #463 