### PR TITLE
fix ovewrite issue #753

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 tsconfig.json
 docs/
 
-LICENSE
 readme.md

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+tsconfig.json
+docs/
+
+LICENSE
+readme.md

--- a/src/toolbox/prompt-tools.ts
+++ b/src/toolbox/prompt-tools.ts
@@ -1,13 +1,9 @@
 import { GluegunEnquirer, GluegunPrompt } from './prompt-types'
 
-let enquirer: GluegunEnquirer = null
 function getEnquirer(): GluegunEnquirer {
-  if (enquirer) return enquirer
-
   const Enquirer: GluegunEnquirer = require('enquirer')
-  enquirer = new Enquirer()
 
-  return enquirer
+  return new Enquirer()
 }
 
 /**


### PR DESCRIPTION
Hello @jamonholmgren 

Don't know the reason to reuse the same `enquirer` instance but when I use a new one for each `prompt` command, the issue disappears on my side.

I took the initiative to add a .npmignore and remove documentation from the npm package.
Just a suggestion, I can remove it if you need it for any reason.
