### PR TITLE
fix(docs): remove ./docs from links in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -103,9 +103,9 @@ module.exports = {
 }
 ```
 
-See the [toolbox api docs](./docs/toolbox-api.md) for more details on what you can do.
+See the [toolbox api docs](./toolbox-api.md) for more details on what you can do.
 
-See the [runtime docs](./docs/runtime.md) for more details on building your own CLI and join us in the #gluegun channel of the Infinite Red Community Slack ([community.infinite.red](http://community.infinite.red)) to get friendly help!
+See the [runtime docs](./runtime.md) for more details on building your own CLI and join us in the #gluegun channel of the Infinite Red Community Slack ([community.infinite.red](http://community.infinite.red)) to get friendly help!
 
 # Who Is Using This?
 


### PR DESCRIPTION
Fix getting page not found, when using links in docs/README.md

The issue:

![docs-readme-issue](https://user-images.githubusercontent.com/37980706/155518426-f2c98c66-840c-44b7-b7b2-93c38047bb4d.gif)

