### PR TITLE
Changed ejs dependency version to 3.1.7.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "colors": "1.4.0",
     "cosmiconfig": "7.0.1",
     "cross-spawn": "7.0.3",
-    "ejs": "3.1.6",
+    "ejs": "3.1.7",
     "enquirer": "2.3.6",
     "execa": "5.1.1",
     "fs-jetpack": "4.3.1",


### PR DESCRIPTION
The new version is required to fix template injection vulnerability in ejs https://github.com/advisories/GHSA-phwq-j96m-2c2q.