### PR TITLE
Coalesce boolean arguments to actual Boolean type instead of string

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "integration": "yarn build && jest --config=./.circleci/jest-integration.config.json",
     "test": "jest",
     "watch": "jest --watch",
+    "watch:debug": "yarn watch --runInBand --verbose",
     "snapupdate": "jest --updateSnapshot",
     "windows:test": "yarn && yarn format && yarn test && yarn clean-build && yarn compile && yarn copy-templates && jest --config=./.circleci/jest-integration.config.json",
     "ci:test": "yarn lint && yarn test --maxWorkers=2 && yarn integration",

--- a/src/runtime/runtime-parameters.test.ts
+++ b/src/runtime/runtime-parameters.test.ts
@@ -47,7 +47,7 @@ test('can pass arguments with mixed options', async () => {
   expect(parameters.command).toBe('hello')
   expect(parameters.options.foo).toBe(true)
   expect(parameters.options.n).toBe(1)
-  expect(parameters.options.chocolate).toBe('true')
+  expect(parameters.options.chocolate).toBe(true)
 })
 
 test('properly infers the heirarchy from folder structure', async () => {

--- a/src/toolbox/parameter-tools.test.ts
+++ b/src/toolbox/parameter-tools.test.ts
@@ -1,0 +1,44 @@
+import { parseParams } from './parameter-tools'
+
+describe('parameter-tools', () => {
+  describe('parseParams', () => {
+    const cases = [
+      {
+        name: 'should coalesce --key=false boolean arguments',
+        input: 'node ignite/bin/ignite new PizzaApp --overwrite=false',
+        output: { array: ['node', 'ignite/bin/ignite', 'new', 'PizzaApp'], options: { overwrite: false } },
+      },
+      {
+        name: 'should coalesce --key=true boolean arguments',
+        input: 'node ignite/bin/ignite new PizzaApp --overwrite=true',
+        output: { array: ['node', 'ignite/bin/ignite', 'new', 'PizzaApp'], options: { overwrite: true } },
+      },
+      {
+        name: 'should coalesce --key true boolean arguments',
+        input: 'node ignite/bin/ignite new PizzaApp --overwrite true',
+        output: { array: ['node', 'ignite/bin/ignite', 'new', 'PizzaApp'], options: { overwrite: true } },
+      },
+      {
+        name: 'should coalesce --key false boolean arguments',
+        input: 'node ignite/bin/ignite new PizzaApp --overwrite false',
+        output: { array: ['node', 'ignite/bin/ignite', 'new', 'PizzaApp'], options: { overwrite: false } },
+      },
+      {
+        name: 'should coalesce --key flag with no value to true',
+        input: 'node ignite/bin/ignite new PizzaApp --overwrite',
+        output: { array: ['node', 'ignite/bin/ignite', 'new', 'PizzaApp'], options: { overwrite: true } },
+      },
+      {
+        name: 'should coalesce --key=0 number arguments to number type',
+        input: 'node ignite/bin/ignite new PizzaApp --port=8080',
+        output: { array: ['node', 'ignite/bin/ignite', 'new', 'PizzaApp'], options: { port: 8080 } },
+      },
+    ]
+
+    cases.forEach(({ name, input, output }) => {
+      it(name, () => {
+        expect(parseParams(input)).toEqual(output)
+      })
+    })
+  })
+})

--- a/src/toolbox/parameter-tools.ts
+++ b/src/toolbox/parameter-tools.ts
@@ -1,6 +1,7 @@
 import { GluegunParameters } from '../domain/toolbox'
 import { Options } from '../domain/options'
 import { equals, is } from './utils'
+import type yargsParser from 'yargs-parser'
 
 const COMMAND_DELIMITER = ' '
 
@@ -12,7 +13,7 @@ const COMMAND_DELIMITER = ' '
  * @returns Normalized parameters.
  */
 export function parseParams(commandArray: string | string[], extraOpts: Options = {}): GluegunParameters {
-  const yargsParse = require('yargs-parser')
+  const yargsParse: yargsParser.Parser = require('yargs-parser')
 
   // use the command line args if not passed in
   if (is(String, commandArray)) {

--- a/src/toolbox/parameter-tools.ts
+++ b/src/toolbox/parameter-tools.ts
@@ -32,7 +32,19 @@ export function parseParams(commandArray: string | string[], extraOpts: Options 
   const parsed = yargsParse(commandArray)
   const array = parsed._.slice()
   delete parsed._
-  const options = { ...parsed, ...extraOpts }
+  const normalizedParsed: Options = Object.fromEntries(
+    Object.entries(parsed).map(([key, value]) => {
+      // if value is 'true' or 'false', convert to boolean
+      if (value === 'true') {
+        return [key, true]
+      }
+      if (value === 'false') {
+        return [key, false]
+      }
+      return [key, value]
+    }),
+  )
+  const options = { ...normalizedParsed, ...extraOpts }
   return { array, options }
 }
 


### PR DESCRIPTION
When we pass `--key=false` flag arguments to gluegun, we get `{ options: { key: 'false' } }` instead of `{ options: { key: 'false' } }`. 

This isn't how I expect to consume these in commands. This can handled on the program level, but I feel like that it should be handled on the gluegun level since I can't imagine a use case where we'd want true or false to be a string 