### PR TITLE
[FIX] - ts-node version to 10.9.1 [Crash on new TS Project]

### DIFF
--- a/src/cli/templates/cli/package.json.ejs
+++ b/src/cli/templates/cli/package.json.ejs
@@ -47,7 +47,7 @@
       "@typescript-eslint/eslint-plugin": "^4.17.0",
       "@typescript-eslint/parser": "^4.17.0",
       "ts-jest": "^26.5.3",
-      "ts-node": "^9.1.1",
+      "ts-node": "^10.9.1",
       "typescript": "^4.2.3",
     <% } %>
     "copyfiles": "^2.4.1",


### PR DESCRIPTION

After creating a new project, the following error was generated:
![Captura de Tela 2023-02-23 às 11 57 45](https://user-images.githubusercontent.com/44801113/220944609-9ffde4cb-b415-483a-a6bc-ab07a50fba5a.png)


So after updating the ts-node version it worked correctly:

![Captura de Tela 2023-02-23 às 11 58 39](https://user-images.githubusercontent.com/44801113/220944780-28cb3a9c-e0fa-433d-90c8-4c942d79b36a.png)

