### PR TITLE
update typescript to version 5.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "temp-write": "4.0.0",
     "ts-jest": "^27.1.3",
     "ts-node": "10.4.0",
-    "typescript": "4.5.2",
+    "typescript": "^5.0.4",
     "unique-temp-dir": "1.0.0"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7364,10 +7364,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
-  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
+typescript@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 uglify-js@^3.1.4:
   version "3.14.5"


### PR DESCRIPTION
Update typescript version to resolve this error when using typescript mode.

Error  ts.Debug.assert(typeof typeReferenceDirectiveName === "string", "Non-string value passed to `ts.resolveTypeReferenceDirective`, likely by a wrapping package working with an outdated `resolveTypeReferenceDirectives` signature. This is probably not a problem in TS itself.");