### PR TITLE
Convert docs to ir-docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,16 +75,16 @@ jobs:
 
 # Parameters for the publish-docs orb
 publish-details: &publish-details
-  description: "Use MLKit Models in React Native apps"
-  git_email: "ci@infinite.red"
-  git_username: "Infinite Red CI"
-  label: "React Native MLKit"
-  project_name: 'react-native-mlkit'
-  source_docs_dir: docs
-  source_repo_directory: "source"
-  target_docs_dir: "docs"
-  target_repo: "git@github.com:infinitered/ir-docs.git"
-  target_repo_directory: "target"
+  description: Use MLKit Models in React Native apps
+  git_email: ci@infinite.red
+  git_username: Infinite Red CI
+  label: Gluegun
+  project_name: gluegun
+  source_docs_dir: ir-docs
+  source_repo_directory: source
+  target_docs_dir: docs
+  target_repo: git@github.com:infinitered/ir-docs.git
+  target_repo_directory: target
 
 workflows:
   version: 2
@@ -106,27 +106,27 @@ workflows:
     jobs:
       - publish-docs/publish_docs:
           <<: *publish-details
-  test_docs:
-    when:
-      and:
-        - not: << pipeline.parameters.force-docs >>
-        - true  # Placeholder for correct YAML structure
-    jobs:
-      - publish-docs/build_docs:
-          <<: *publish-details
-          filters:
-            branches:
-              ignore:
-                - main
-  publish_docs:
-    when:
-      and:
-        - not: << pipeline.parameters.force-docs >>
-        - true  # Placeholder for correct YAML structure
-    jobs:
-      - publish-docs/publish_docs:
-          <<: *publish-details
-          filters:
-            branches:
-              only:
-                - main
+#  test_docs:
+#    when:
+#      and:
+#        - not: << pipeline.parameters.force-docs >>
+#        - true  # Placeholder for correct YAML structure
+#    jobs:
+#      - publish-docs/build_docs:
+#          <<: *publish-details
+#          filters:
+#            branches:
+#              ignore:
+#                - main
+#  publish_docs:
+#    when:
+#      and:
+#        - not: << pipeline.parameters.force-docs >>
+#        - true  # Placeholder for correct YAML structure
+#    jobs:
+#      - publish-docs/publish_docs:
+#          <<: *publish-details
+#          filters:
+#            branches:
+#              only:
+#                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
 
-version: 2
+version: 2.1
 
 orbs:
   publish-docs: infinitered/publish-docs@0.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,21 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
 
+version: 2
+
+orbs:
+  publish-docs: infinitered/publish-docs@0.4
+
+parameters:
+  "force-docs":
+    type: boolean
+    default: false
+
 defaults: &defaults
-  docker:
-    # Choose the version of Node you want here
+  docker: # Choose the version of Node you want here
     - image: cimg/node:18.17.1
   working_directory: ~/repo
 
-version: 2
 jobs:
   setup:
     <<: *defaults
@@ -65,6 +73,19 @@ jobs:
           name: Publish to NPM
           command: yarn ci:publish # this will be added to your package.json scripts
 
+# Parameters for the publish-docs orb
+publish-details: &publish-details
+  description: "Use MLKit Models in React Native apps"
+  git_email: "ci@infinite.red"
+  git_username: "Infinite Red CI"
+  label: "React Native MLKit"
+  project_name: 'react-native-mlkit'
+  source_docs_dir: docs
+  source_repo_directory: "source"
+  target_docs_dir: "docs"
+  target_repo: "git@github.com:infinitered/ir-docs.git"
+  target_repo_directory: "target"
+
 workflows:
   version: 2
   test_and_release:
@@ -79,3 +100,33 @@ workflows:
           filters:
             branches:
               only: master
+  # for testing and debugging
+  force-docs:
+    when: << pipeline.parameters.force-docs >>
+    jobs:
+      - publish-docs/publish_docs:
+          <<: *publish-details
+  test_docs:
+    when:
+      and:
+        - not: << pipeline.parameters.force-docs >>
+        - true  # Placeholder for correct YAML structure
+    jobs:
+      - publish-docs/build_docs:
+          <<: *publish-details
+          filters:
+            branches:
+              ignore:
+                - main
+  publish_docs:
+    when:
+      and:
+        - not: << pipeline.parameters.force-docs >>
+        - true  # Placeholder for correct YAML structure
+    jobs:
+      - publish-docs/publish_docs:
+          <<: *publish-details
+          filters:
+            branches:
+              only:
+                - main

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,8 +1,9 @@
 - [Home](/)
-- [Getting Started](/getting-started)
-- [Runtime API](/runtime)
-- [Toolbox API](/toolbox-api)
-  - [config](/toolbox-config)
+
+* [Getting Started](/getting-started)
+* [Runtime API](/runtime)
+* [Toolbox API](/toolbox-api)
+  - [config](/ir-docs/toolbox-api/config.md)
   - [filesystem](/toolbox-filesystem)
   - [semver](/toolbox-semver)
   - [http](/toolbox-http)
@@ -14,10 +15,10 @@
   - [template](/toolbox-template)
   - [patching](/toolbox-patching)
   - [packageManager](/toolbox-package-manager)
-- Tutorials
+* Tutorials
   - [Tutorial: Making a Movie CLI](/tutorial-making-a-movie-cli)
   - [Tutorial: Making a Plugin](/tutorial-making-a-plugin)
-- Guides
+* Guides
   - [Guide: Architecting Your Gluegun CLI](/guide-architecture)
-- [Plugins](/plugins)
-- [Contributing](/contributing)
+* [Plugins](/plugins)
+* [Contributing](/contributing)

--- a/ir-docs/contributing/_category_.json
+++ b/ir-docs/contributing/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Guides",
+  "position": 600,
+  "link": {
+    "type": "doc",
+    "id": "index"
+  }
+}

--- a/ir-docs/contributing/index.md
+++ b/ir-docs/contributing/index.md
@@ -1,0 +1,94 @@
+# Contributing
+
+_Welcome!_
+
+Bug fixes, features, docs, marketing, and issue support are all contributions. We love it when people help out and are more than willing to give you advice, guidance, or just be a 🐥 debugger for you.
+
+## Global Dependencies
+
+If you're reading this, you might be interested in pitching in from a code point of view.
+
+`gluegun` is powered by Node (7.6 or above). Install Node using `brew` (if on macOS) or by following the instructions here: [https://nodejs.org/en/download/current/](https://nodejs.org/en/download/current/)
+
+Also install yarn: `brew install yarn` or [https://yarnpkg.com](https://yarnpkg.com).
+
+## Installing `gluegun`
+
+Next, fork the repo [on Github](https://github.com/infinitered/gluegun) and clone down your repo.
+
+```sh
+git clone git@github.com/<yourusername>/gluegun
+```
+
+Install all the dependencies.
+
+```
+cd gluegun
+yarn
+```
+
+Gluegun's source files are mostly in `./src` and are written in [TypeScript](www.typescriptlang.org). Documentation lives in `/docs`.
+
+## Running Tests And Linting
+
+On macOS or Linux:
+
+```sh
+yarn test
+yarn lint
+yarn watch
+yarn integration
+```
+
+On windows:
+
+```sh
+yarn lint
+yarn windows:test
+```
+
+## Features & Fixes
+
+```sh
+git branch feature/fun
+# furious typing
+yarn test
+yarn lint
+git commit -m "Adds fun"
+git push -u origin --HEAD
+```
+
+Passing tests and linting is required before we'll merge a pull request. If you need help with this, feel free to file an issue or chat with us on the [Infinite Red Community Slack](http://community.infinite.red).
+
+## Submitting a Pull Request
+
+Jump on Github on your fork. Switch to the branch with your new changes, and
+open a PR against `master` of [infinitered/gluegun](https://github.com/infinitered/gluegun).
+
+Screenshots of what the feature is 💯. Animated gifs (suggested apps: licecap, Gif Brewery, or Kap) are 💯 + 🦄.
+
+Then submit the pull request.
+
+- It's okay to submit an issue before breaking changes or shenanigans to get a sense if it's cool
+- It's okay to submit PRs to start a discussion - just mark it 🚨🚨🚨 (or whatever) to let us know it's a conversation
+- It's okay to submit changes to PRs not yet merged, just make sure it's related to the PR
+- If Github is complaining about conflicts, rebase downstream, merge upstream
+
+## Keeping up to date
+
+You want your fork's `master` to be the same as `gluegun/master`.
+
+```sh
+# just once, run this to track our repo as `upstream`
+git remote add upstream https://github.com/infinitered/gluegun.git
+
+# then when you need to update
+git checkout master
+git pull upstream
+# if on your own branch
+git checkout <your branch>
+git merge master
+
+# and here's where you'd create your branch
+git checkout -b feature/mybranch
+```

--- a/ir-docs/contributing/releasing.md
+++ b/ir-docs/contributing/releasing.md
@@ -1,0 +1,10 @@
+# Releasing Gluegun
+
+We now have CircleCI continuous integration and continous deployment set up! Thanks to Morgan Laco for setting that up.
+
+To release, just squash and merge a pull request and prefix with one of the following:
+
+- "fix: Some feature" - will release a patch version (aka 1.0.1)
+- "feat: Some feature" - will release a feature version (aka 1.1.0)
+- "feat: BREAKING CHANGE: Some breaking change" - will release a breaking version (aka 2.0.0)
+- "doc: Some docs" or "chore: Some chore" won't release

--- a/ir-docs/getting-started.md
+++ b/ir-docs/getting-started.md
@@ -1,0 +1,141 @@
+---
+sidebar_position: 200
+---
+
+# Getting Started
+
+The fastest way to get started is to use the built-in Gluegun CLI (very meta!) to generate it.
+
+## Creating a new Gluegun-powered CLI
+
+Gluegun works on macOS, Linux, and Windows 10. First, ensure you have Node installed and that you can access it (minimum version 7.6):
+
+```
+$ node --version
+```
+
+We will also be using [yarn](https://yarnpkg.com/) in this guide rather than `npm`. You can use `npm` if you want.
+
+Install `gluegun` globally.
+
+```
+$ yarn global add gluegun
+```
+
+Next, navigate to the folder you'd like to create your CLI in and generate it.
+
+```
+$ gluegun new mycli
+```
+
+Gluegun will ask if you want to use TypeScript or modern JavaScript:
+
+```
+? Which language would you like to use? (Use arrow keys)
+  TypeScript - Gives you a build pipeline out of the box (default)
+  Modern JavaScript - Node 8.2+ and ES2016+ (https://node.green/)
+```
+
+You can also pass in `--typescript` or `--javascript` (or `-t` or `-j` for short) to bypass the prompt:
+
+```
+$ gluegun new mycli -t
+$ gluegun new mycli -j
+```
+
+_Note: We recommend TypeScript, but you don't have to use it! Gluegun works great with modern JavaScript._
+
+## Linking your CLI so you can access it
+
+Navigate to the new `mycli` folder and run `yarn link` to have it available globally on your command line.
+
+```
+$ cd mycli
+$ yarn link
+$ mycli --help
+```
+
+## Creating your first command
+
+Your Gluegun-powered CLI isn't very useful without a command! In your CLI, create a new JS file in `src/commands` called `hello.js`. In that file, add this:
+
+```js
+// src/commands/hello.js
+module.exports = {
+  run: async (toolbox) => {
+    toolbox.print.info('Hello, world!')
+  },
+}
+```
+
+For TypeScript, it's not much different:
+
+```typescript
+// src/commands/hello.ts
+import { GluegunToolbox } from 'gluegun'
+module.exports = {
+  run: async (toolbox: GluegunToolbox) => {
+    toolbox.print.info('Hello, world!')
+  },
+}
+```
+
+Now run your command:
+
+```
+$ mycli hello
+Hello, world!
+```
+
+Yay!
+
+## Creating your first extension
+
+You can add more tools into the `toolbox` for _all_ of your commands to use by creating an `extension`. In your `mycli` folder, add a new file in `src/extensions` called `hello-extension.js`. (It doesn't _have_ to end in `-extension`, but that's a convention.)
+
+```js
+// src/extensions/hello-extension.js
+module.exports = async (toolbox) => {
+  toolbox.hello = () => {
+    toolbox.print.info('Hello from an extension!')
+  }
+}
+```
+
+Or TypeScript:
+
+```typescript
+// src/extensions/hello-extension.ts
+import { GluegunToolbox } from 'gluegun'
+module.exports = async (toolbox: GluegunToolbox) => {
+  toolbox.hello = () => {
+    toolbox.print.info('Hello from an extension!')
+  }
+}
+```
+
+Then, in your `hello` command, use that function instead:
+
+```js
+// src/commands/hello.js
+module.exports = {
+  run: (toolbox) => {
+    const { hello } = toolbox
+
+    hello()
+  },
+}
+```
+
+When you run the command, this time it'll use the extension's output.
+
+```
+$ mycli hello
+Hello from an extension!
+```
+
+Note that we sometimes call the `toolbox` the `context` or the `RunContext`. That's just another word for the same thing.
+
+## Next steps
+
+There are _many_ more tools in the toolbox than just `print.info`. You can generate from a template, manipulate files, hit API endpoints via HTTP, access parameters, run system commands, ask for user input, and much more. Explore the [API docs](./toolbox-api.md) in this folder to learn more or follow a tutorial like [Making a Movie CLI](./tutorial-making-a-movie-cli.md).

--- a/ir-docs/guides/_category_.json
+++ b/ir-docs/guides/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Guides",
+  "position": 600,
+  "link": {
+    "type": "generated-index",
+    "description": "Guides to advanced topics."
+  }
+}

--- a/ir-docs/guides/guide-architecture.md
+++ b/ir-docs/guides/guide-architecture.md
@@ -1,0 +1,176 @@
+# Guide: Architecting Your Gluegun CLI
+
+There are many ways to architect Gluegun-powered CLIs. This guide is intended to be a living document, collecting the lessons learned along the way of building CLIs with Gluegun. It is not necessarily the only correct way to build a CLI.
+
+If you have ideas, suggestions, or questions, feel free to [open an issue](https://github.com/infinitered/gluegun/issues/new)!
+
+## Commands
+
+Commands should be focused on user interaction and not necessarily on implementation details. Don't write your whole app inside a command; instead, parse out user-provided info, then delegate to other functions (which can be provided via extensions, which are described below) to do work.
+
+_Do this_
+
+```js
+module.exports = {
+  name: 'world',
+  alias: ['w', 'earth'],
+  run: async (toolbox) => {
+    // in this case, `hello` is provided by an extension
+    const { hello, prompt } = toolbox
+
+    // user interaction is great in a command
+    const isEarthling = await prompt.confirm('Are you an earthling?')
+
+    // delegate the actual work to an extension
+    if (isEarthling) {
+      hello.greetEarthling()
+    } else {
+      hello.greetAlien()
+    }
+  },
+}
+```
+
+### Commands file structure
+
+Nest commands in a folder structure that mirrors their command line equivalent. Unlike other libraries, we don't use `index.js` for the default command in a folder. Instead, use the same name as the folder. This helps avoid the situation where you might have 12 `index.js` files open in your editor, which is confusing.
+
+For example:
+
+_Don't do this_
+
+```
+commands
+  hello
+    index.js
+```
+
+_Do this_
+
+```
+commands
+  hello
+    hello.js
+```
+
+_Or this_
+
+```
+commands
+  hello.js
+```
+
+If you have nested commands, keep them all in the folder, like this:
+
+```
+commands
+  hello
+    hello.js
+    world.js
+```
+
+You don't have to have a default command for a folder. Gluegun will pick up on it (as of 2.0.0-beta.7).
+
+```
+commands
+  hello
+    world.js
+```
+
+As of Gluegun 4.1.0, you can also nest commands in a `build` folder, if for example you're using TypeScript and want to compile to `./build`.
+
+## Extensions
+
+Think of extensions as "drawers" full of tools in your Gluegun toolbox. In the above example, the `hello` extension adds two functions, `greetEarthling` and `greetAlien`.
+
+```js
+module.exports = (toolbox) => {
+  const { print } = toolbox
+  toolbox.hello = {
+    greetEarthling: () => print.info('Hello, earthling!'),
+    greetAlien: () => print.info('Greetings, alien!'),
+  }
+}
+```
+
+_Hint: In most cases, you probably don't want to use `prompt` in your extensions. They should be more general purpose tools and not specific user flows._
+
+### Additional Functionality
+
+The above code snippet is a good simple example of an extension. However, as your extensions grow, you'll probably find that they start getting quite large. In that case, you'll probably want to break your functions out into separate folders.
+
+Just like Gluegun itself, we recommend a separate folder for these. Gluegun uses `src/toolbox`, but you can name it whatever makes sense for you. Here's an example:
+
+```
+commands
+  hello
+    world.js
+extensions
+  hello-extension.js
+toolbox
+  greetings
+    earthling.js
+    martian.js
+    venusian.js
+```
+
+You can access Gluegun tools by using `require` (or `import` if you're using TypeScript).
+
+```js
+const { print } = require('gluegun/print')
+
+// toolbox/greetings/earth.js
+module.exports = () => print.info('Hello, earthling!'),
+```
+
+Then attach the functions or objects to your toolbox:
+
+```js
+// extensions/hello-extension.js
+const earthling = require('../toolbox/greetings/earthling')
+const martian = require('../toolbox/greetings/martian')
+const venusian = require('../toolbox/greetings/venusian')
+
+module.exports = (toolbox) => {
+  toolbox.hello = { earthling, martian, venusian }
+}
+```
+
+### Performance
+
+If you use many NPM packages, it's a good idea for performance reasons to "hide" `require` statements inside your command `run` functions so only the command that is invoked loads its dependencies. ([Here](https://github.com/aws-amplify/amplify-cli/pull/511) is an example that improved Amazon AWS Amplify CLI performance by nearly 2.5x)
+
+_Don't do this_
+
+```js
+const R = require('ramda')
+
+module.exports = {
+  name: 'mycommand',
+  run: async (toolbox) => {
+    // use Ramda
+  },
+}
+```
+
+_Do this_
+
+```js
+module.exports = {
+  name: 'mycommand',
+  run: async (toolbox) => {
+    const R = require('ramda')
+    // use Ramda
+  },
+}
+```
+
+`require` will only load on-demand when the function is run. It will also only load `ramda` once (in the examples given) even if you `require` multiple times. So you can safely `require('ramda')` in as many functions or extensions as you want.
+
+## Additional Topics
+
+The topics above will get you very far. Some other things to consider as you dig deeper into your CLI are:
+
+1.  Where do I access and store configuration values?
+2.  How do consumers of my CLI install and configure [plugins](../plugins)?
+3.  How will templates be organized? (Hint: look at the [Gluegun CLI source](https://github.com/infinitered/gluegun/tree/master/src/cli))

--- a/ir-docs/index.md
+++ b/ir-docs/index.md
@@ -1,0 +1,10 @@
+# Gluegun <small>2.0</small>
+
+> A delightful toolkit for building Node-powered CLIs.
+
+- Lightweight (~83kB tarball)
+- Batteries included
+- Plugin-ready
+
+[GitHub](https://github.com/infinitered/gluegun)
+[Get Started](#quick-start)

--- a/ir-docs/plugins.md
+++ b/ir-docs/plugins.md
@@ -1,0 +1,147 @@
+---
+sidebar_position: 700
+---
+
+# Plugins
+
+Functionality is added to the `CLI runtime` with plugins. Plugins can be yours or the end users.
+
+A plugin is directory that contains 3 optional sub-directories:
+
+- `commands`
+- `templates`
+- `extensions`
+
+(You can also nest these three directories in `build`, for a build pipeline, and Gluegun will still find them. Requires Gluegun 4.1.0+.)
+
+And 1 optional file, which can be `<brand>.config.js`, `.<brand>rc.json`, or `.<brand>rc.yaml`. Replace `<brand>` with the name of your CLI.
+
+Other than the 3 directories listed, you're welcome to put any other files or sub-directories in the plugin directory. For example, we include a `plugin.js` file in the root of plugins for [Ignite CLI](https://github.com/infinitered/ignite) to help us load it effectively.
+
+Since multiple plugins can be loaded, they must have unique names. The names are indicated by reading the `name` property of the configuration (more on this below), or the plugin directory name itself.
+
+## commands
+
+Commands are run from the command line (CLI).
+
+```
+movies actor
+```
+
+Here, the `actor` command is run. It is a JS file (`src/commands/actor.js`) that exports a structure that looks something like this:
+
+```js
+module.exports = {
+  name: 'actor',
+  alias: ['a'],
+  description: 'Displays the name of an actor',
+  hidden: false,
+  dashed: false,
+  run: async (toolbox) => {
+    const { print } = toolbox
+
+    print.info(`Tom Hanks`)
+  },
+}
+```
+
+The `name` and `description` properties are used in `printCommands` calls to print out some help in a table.
+
+`alias` allows you to invoke these commands using an alias.
+
+`hidden` says whether to show the command in help screens or not.
+
+`dashed` lets you run the command as a dashed command, like `--version` or `-v`.
+
+The `run` property should be a function (async or not) that does whatever you want it to. You'll receive the gluegun `toolbox` object which contains the [core extensions](./toolbox-api.md) and any additional extensions you've loaded.
+
+## templates
+
+Templates are [ejs](http://www.embeddedjs.com/) files that get translated by a command into a source code file or similar. For an example, check out the [Gluegun CLI](https://github.com/infinitered/gluegun/tree/master/src/cli) itself.
+
+## extensions
+
+Extensions are additional functionality that you can monkeypatch onto the `toolbox` object. They look something like this:
+
+```js
+// extensions/sayhello.js
+module.exports = (toolbox) => {
+  const { print } = toolbox
+
+  toolbox.sayhello = () => {
+    print.info('Hello from an extension!')
+  }
+}
+```
+
+When you have this extension, you can access it in any command file, like this:
+
+```js
+// ...
+run: async (toolbox) => {
+  const { sayhello } = toolbox
+
+  sayhello()
+
+  // or
+
+  toolbox.sayhello()
+}
+```
+
+### async extensions
+
+Extensions maybe also be asynchronous, allowing for things like network calls or other asynchronous operations.
+
+```js
+// extensions/getMyData.js
+const { asyncCall } = require('@company/lib')
+
+module.exports = async (toolbox) {
+  const { data } = await asyncCall()
+  toolbox.myData = data
+}
+```
+
+# Configuration File
+
+Gluegun uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) to determine configuration. It can be:
+
+- an object under the `<brand>` key in the `package.json`
+- a `.<brand>rc` file (containing either yaml or json)
+- `.<brand>rc.json` file
+- `.<brand>rc.yaml` file
+- `<brand>.config.js` JS file that exports an object
+
+In this configuration, you can configure your plugin's name and also set up certain user-overridable defaults.
+
+## name
+
+The name of your plugin. If `name` does not exist, the default will be the name of the directory.
+
+```json
+{
+  "name": "something"
+}
+```
+
+Since many plugins can be installed, we recommend namespacing them with your CLI. For example, for [Ignite](https://github.com/infinitered/ignite) plugins we have `ignite-i18n`, `ignite-maps`, etc. For [Solidarity](https://github.com/infinitered/solidarity), we have `solidarity-react-native` and `solidarity-elixir`.
+
+A name:
+
+- can contain **numbers & letters**
+- should be **lowercase**
+- spaces-should-have-**dashes**-if-you-need-them
+
+## defaults
+
+Default configuration settings which may be used by your commands and overridden by end users.
+
+```json
+{
+  "semicolons": true,
+  "colorTheme": ["red", "no", "blue", "aaaaaaaaa"]
+}
+```
+
+If you'd like to follow a tutorial to make a plugin, check out the ["Making a Plugin" tutorial](./tutorial-making-a-plugin.md).

--- a/ir-docs/runtime.md
+++ b/ir-docs/runtime.md
@@ -1,0 +1,358 @@
+---
+sidebar_position: 300
+---
+
+# Runtime
+
+Gluegun provides a builder that lets you initialize and configure Gluegun to work with your CLI. It lets you load & execute commands, extensions, and plugins.
+
+_Note: Check out the [sniff](./sniff) module for detecting if your environment is able to run._
+
+Here's a kitchen sink version, which we're about to cover.
+
+```js
+const { build } = 'gluegun'
+
+const cli = build('movie')
+  .src(__dirname)
+  .plugin('~/.movie/movie-imdb')
+  .plugins('./node_modules', { pattern: 'movie-' })
+  .help()
+  .version()
+  .defaultCommand()
+  .command({ name: 'hi', run: (toolbox) => toolbox.print.info('hi!') })
+  .exclude(['filesystem', 'semver', 'system', 'prompt', 'http'])
+  .checkForUpdates(5) // check for updates randomly about 5% of the time
+  .create()
+
+await cli.run()
+```
+
+## build
+
+Grab the `build` function from `gluegun`.
+
+```js
+const { build } = require('gluegun')
+```
+
+Now let's build a `gluegun` cli environment by configuring various features.
+
+```js
+const cli = build('mycli')
+```
+
+The `mycli` brand that you pass into `build` is used through-out gluegun for things like configuration file names and folder names for plugins. You can also set it later, like this:
+
+```js
+const cli = build().brand('movie')
+```
+
+Out of the box, this CLI does very little. And by very little I mean nothing. So let's configure this. We'll be chaining the `build()` function from here.
+
+## src
+
+This sets where the default commands and extensions are located, in
+`commands` and `extensions` folders, respectively.
+
+```js
+const cli = build('movie').src(__dirname)
+```
+
+When you run a command, it'll first load extensions in this folder and then check the commands in this folder for the right command.
+
+```sh
+# run a command with arguments
+$ movie actors Kingpin
+
+# run a command with arguments & options
+$ movie producers "Planes, Trains, & Automobiles" --sort age
+```
+
+## plugin
+
+Additional functionality can be added to the `gluegun` object with [plugins](./plugins). Plugins can be yours or your users.
+
+_Hint: `src` and `plugin` are almost identical under the hood. The only thing they do differently is `src` will be loaded first and be the "default plugin"._
+
+A plugin is a folder (or, more often, an NPM package) that contains a structure - something like this:
+
+```
+movie-credits
+  commands
+    actors.js
+    producers.js
+  extensions
+    retrieve-imdb.js
+  templates
+    actor-view.js.ejs
+  movie.config.js
+```
+
+You can load a plugin from a directory:
+
+```js
+const cli = build('movie').src(__dirname).plugin('~/.movie/movie-imdb')
+```
+
+## plugins
+
+You can also load multiple plugins within a directory.
+
+```js
+const cli = build('movie').src(__dirname).plugin('~/.movie/movie-imdb').plugins('./node_modules', { pattern: 'movie-' })
+```
+
+`plugins` supports a `fs-jetpack` [matching pattern](https://github.com/szwacz/fs-jetpack#findpath-searchoptions) so you can filter out a subset of directories instead of just all.
+
+```js
+  .plugins('./node_modules', { matching: 'movies-*' })
+```
+
+If you would like to keep plugins hidden and not available at the command line:
+
+```js
+  .plugins('./node_modules', { matching: 'movies-*', hidden: true })
+```
+
+When plugins are hidden they can still be run directly from the cli.
+
+## help
+
+Gluegun ships with a somewhat adequate `help` screen out of the box. Add it to your
+CLI easily by calling `.help()`.
+
+```js
+const cli = build('movie')
+  .src(__dirname)
+  .plugins('./node_modules', { pattern: 'movie-' })
+  .plugin('~/.movie/movie-imdb')
+  .help()
+```
+
+You can also pass in a function or command object here:
+
+```js
+  .help(toolbox => toolbox.print.info('No help for you!'))
+  .help({
+    name: 'help',
+    alias: 'helpmeplease',
+    hidden: true,
+    dashed: true,
+    run: toolbox => toolbox.print.info('No help for you!')
+  })
+```
+
+## version
+
+You usually like to be able to run `--version` to see your CLI's version from the command
+line, so add it easily with `.version()`.
+
+```js
+const cli = build('movie')
+  .src(__dirname)
+  .plugins('./node_modules', { pattern: 'movie-' })
+  .plugin('~/.movie/movie-imdb')
+  .help()
+  .version()
+```
+
+Just like `help` above, you can pass in a function or command object to configure it further.
+
+## defaultCommand
+
+If the user runs your CLI and doesn't supply any matching parameters, it'll run this command
+instead. Note that you can do this by supplying a `<brand>.js` file in your `./commands`
+folder as well.
+
+```js
+const cli = build('movie')
+  .src(__dirname)
+  .plugins('./node_modules', { pattern: 'movie-' })
+  .plugin('~/.movie/movie-imdb')
+  .help()
+  .version()
+  .defaultCommand()
+```
+
+Just like `help` and `version` above, you can pass in a function or command object if
+you prefer more control.
+
+## command
+
+If you want to pass in commands directly to the runtime builder, you can do that with `.command()`.
+
+```js
+const cli = build('movie')
+  .src(__dirname)
+  .plugins('./node_modules', { pattern: 'movie-' })
+  .plugin('~/.movie/movie-imdb')
+  .help()
+  .version()
+  .defaultCommand()
+  .command({ name: 'hi', run: (toolbox) => toolbox.print.info('hi!') })
+```
+
+In this case, if you ran `movie hi`, it would run the function provided and print out 'hi!'.
+
+You must provide an object with at least a `name` and a `run` function, which can be
+`async` or regular.
+
+## exclude
+
+If you don't need certain core extensions, you can skip loading them (thus improving startup time) by using `.exclude()`. Just pass in an array of string names for the core extensions you don't need.
+
+```js
+const cli = build('movie').exclude([
+  'meta',
+  'strings',
+  'print',
+  'filesystem',
+  'semver',
+  'system',
+  'prompt',
+  'http',
+  'template',
+  'patching',
+])
+```
+
+If you find you need one of these extensions for just _one_ command but don't want to load it for _all_ of your commands, you can always load it separately from the Gluegun toolbox, like this:
+
+```js
+const { prompt } = require('gluegun')
+// or
+const { prompt } = require('gluegun/prompt')
+```
+
+For reference, the core extensions that incur the biggest startup performance penalty are (timing varies per machine, but this gives some sense of scale):
+
+```
+prompt +100ms
+print +45ms
+http +30ms
+system +10ms
+```
+
+_Note about TypeScript and `exclude`:_ Please note that the TypeScript type `GluegunToolbox` (as of Gluegun 2.1.x) always assumes that core extensions are included, even if you excluded them in the builder. In this case, it's recommended that you create your own `FooToolbox` (or similar) and update the interface to match your preferred configuration. Example:
+
+```typescript
+// wherever your types are, say, `./src/types.ts`
+import { GluegunToolbox } from 'gluegun'
+export interface FooToolbox extends GluegunToolbox {
+  prompt: null
+  print: null
+  http: null
+  system: null
+}
+
+// in a command
+import { FooToolbox } from '../types'
+module.exports = {
+  run: async (toolbox: FooToolbox) => {
+    // ... use toolbox with your excluded extensions
+  },
+}
+```
+
+## checkForUpdates
+
+This allows you to check for updates every so often. Because we don't track how often your CLI is run, instead, we allow you to set a percentage chance of checking for updates. We recommend somewhere between 1-20, depending on how often your CLI is run. If you want to run it every time, set it to 100.
+
+```js
+const cli = build('movie')
+  .src(__dirname)
+  .plugins('./node_modules', { pattern: 'movie-' })
+  .plugin('~/.movie/movie-imdb')
+  .help()
+  .version()
+  .defaultCommand()
+  .command({ name: 'hi', run: (toolbox) => toolbox.print.info('hi!') })
+  .checkForUpdates(5)
+```
+
+## create
+
+At this point, we've been configuring our CLI. When we're ready, we call `create()`:
+
+```js
+const cli = build('movie')
+  .src(__dirname)
+  .plugins('./node_modules', { pattern: 'movie-' })
+  .plugin('~/.movie/movie-imdb')
+  .help()
+  .version()
+  .defaultCommand()
+  .command({ name: 'hi', run: (toolbox) => toolbox.print.info('hi!') })
+  .checkForUpdates(5)
+  .create()
+```
+
+This command applies the configuration that you were just chaining, and turns it into a `runtime cli` which supports calling `run()`.
+
+And now we're ready to run:
+
+```js
+cli.run()
+```
+
+With no parameters, `gluegun` will parse the command line arguments looking for the command to run.
+
+```sh
+# list the plugins
+$ movie
+
+# run a command
+$ movie quote
+
+# run a command with options
+$ movie quote --funny
+
+# run a command with arguments
+$ movie actors Kingpin
+
+# run a command with arguments & options
+$ movie producers "Planes, Trains, & Automobiles" --sort age
+```
+
+## run
+
+`gluegun` can also be `run()` with options.
+
+```js
+await cli.run('quote random "*johnny"', {
+  funny: true,
+  genre: 'Horror',
+  weapon: 'axe',
+})
+```
+
+There's a few situations that make this useful.
+
+1.  Maybe you like to use `meow` or `commander` to parse the command line.
+2.  Maybe your interface isn't a CLI.
+3.  Maybe you want to run several commands in a row.
+4.  Maybe this is your program and you don't like strangers telling you how to code.
+
+Bottom line is, you get to pick. It's yours. `gluegun` is just glue.
+
+## configuration
+
+Each plugin can have its own configuration file where it places defaults. These defaults can then be overridden by reading defaults from a configuration file or entry in `package.json`. We use [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) for this.
+
+It will read the plugin name from the `name` key and the defaults will be read from the `defaults` section. Each section underneath `default` can be used to override the sections of the plugin. Since that was horribly explained, here's an example.
+
+```js
+// in movies.config.js
+module.exports = {
+  name: 'movies',
+  defaults: {
+    movie: {
+      cache: '~/.movies/cache',
+    },
+    another: {
+      count: 100,
+    },
+  },
+}
+```

--- a/ir-docs/sniff.md
+++ b/ir-docs/sniff.md
@@ -1,0 +1,31 @@
+---
+sidebar_position: 800
+---
+
+# Sniff
+
+The `gluegun` requires a Node 7.6.0 environment which provides `async` and `await` support natively.
+
+You can safely check these requirements by using the `sniff` module.
+
+```js
+const { ok } = require('gluegun/sniff')
+
+if (ok) {
+  // we are clear for lift-off
+}
+```
+
+The `ok` property will be `true` if everything is good to go.
+
+`sniff` also has a few more properties you can use for better errors.
+
+| property      | type   | value                                      |
+| ------------- | ------ | ------------------------------------------ |
+| ok            | bool   | `true` if everything is good to go         |
+| isNewEnough   | bool   | `true` if we have Node.js >= 7.6.0         |
+| hasAsyncAwait | bool   | `true` if we have `--harmony` enabled      |
+| nodeVersion   | string | the node version such as `'7.6.0'`         |
+| nodeMinimum   | string | the node minimum that sniff is looking for |
+
+These two properties will both be set to `true` if we're running in Node 7.6.0.

--- a/ir-docs/toolbox-api/_category_.json
+++ b/ir-docs/toolbox-api/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Toolbox API",
+  "position": 400,
+  "link": {
+    "type": "doc",
+    "id": "intro",
+    "description": "Useful tools for building your CLI"
+  }
+}

--- a/ir-docs/toolbox-api/config.md
+++ b/ir-docs/toolbox-api/config.md
@@ -1,3 +1,5 @@
+# config
+
 You can have your plugin authors configure the behavior of your CLI by providing a configuration file in the root of any plugin. You can also provide one in the root level of the main CLI.
 
 This is an object. Each plugin will have its own root level key.
@@ -33,7 +35,7 @@ module.exports = {
 It takes the plugin's defaults, and merges the user's changes overtop.
 
 ```js
-module.exports = async toolbox => {
+module.exports = async (toolbox) => {
   toolbox.config.movies // { fun: true, level: 10 }
 }
 ```
@@ -42,7 +44,7 @@ If you'd like to load your own config files, use the `loadConfig` function inclu
 
 ```js
 module.exports = {
-  run: async toolbox => {
+  run: async (toolbox) => {
     const {
       config: { loadConfig },
       print: { info },

--- a/ir-docs/toolbox-api/filesystem.md
+++ b/ir-docs/toolbox-api/filesystem.md
@@ -1,0 +1,116 @@
+# filesystem
+
+A set of functions & values to work with files and directories. The majority of these functions come
+straight from [fs-jetpack](https://github.com/szwacz/fs-jetpack), a fantastic API for working with the
+file system. All jetpack-based functions have an equivalent `*Async` version if you need it.
+
+You can access these tools on the Gluegun toolbox, via `const { filesystem } = require('gluegun')`, or directly via `const { filesystem } = require('gluegun/filesystem')`.
+
+## separator
+
+This value is the path separator `\` or `/` depending on the OS.
+
+```js
+toolbox.filesystem.separator // '/' on posix but '\' on windows
+```
+
+## eol
+
+This value is the end of line byte sequence.
+
+```js
+toolbox.filesystem.eol // '\n' on posix but '\r\n' on windows
+```
+
+## homedir
+
+This function retrieves the path to the home directory.
+
+```js
+toolbox.filesystem.homedir() // '/Users/jh' on my macOS machine
+```
+
+## subdirectories
+
+Finds the immediate subdirectories in a given directory.
+
+```js
+toolbox.filesystem.subdirectories(`~/Desktop`) // []
+```
+
+## append
+
+[Appends](https://github.com/szwacz/fs-jetpack#appendpath-data-options) data to the end of a file.
+
+## chmodSync
+
+Changes directory ownership. See more in the [fs documentation](https://nodejs.org/api/fs.html#fs_fs_chmodsync_path_mode).
+
+## copy
+
+[Copies](https://github.com/szwacz/fs-jetpack#copyfrom-to-options) a file or a directory.
+
+## cwd
+
+Gets the [current working directory](https://github.com/szwacz/fs-jetpack#createreadstreampath-options).
+
+## dir
+
+[Ensures a directory exists](https://github.com/szwacz/fs-jetpack#dirpath-criteria) and creates a new jetpack
+instance with it's `cwd` pointing there.
+
+## exists
+
+Checks to see if file or directory [exists](https://github.com/szwacz/fs-jetpack#existspath).
+
+## file
+
+[Ensures a file exists](https://github.com/szwacz/fs-jetpack#filepath-criteria).
+
+## find
+
+[Finds](https://github.com/szwacz/fs-jetpack#findpath-searchoptions) files or directories.
+
+## inspect
+
+[Grabs information](https://github.com/szwacz/fs-jetpack#inspectpath-options) about a file or directory.
+
+## inspectTree
+
+[Grabs nested information](https://github.com/szwacz/fs-jetpack#inspecttreepath-options) about a set of files or directories.
+
+## list
+
+[Gets a directory listing](https://github.com/szwacz/fs-jetpack#listpath), like `ls`.
+
+## move
+
+[Moves](https://github.com/szwacz/fs-jetpack#movefrom-to) files and directories.
+
+## path
+
+[Grabs path parts](https://github.com/szwacz/fs-jetpack#pathparts) as a string.
+
+## read
+
+[Reads](https://github.com/szwacz/fs-jetpack#readpath-returnas) the contents of a file as a string or JSON.
+
+## remove
+
+[Deletes](https://github.com/szwacz/fs-jetpack#removepath) a file or directory.
+
+## rename
+
+[Renames](https://github.com/szwacz/fs-jetpack#renamepath-newname) a file or directory.
+
+## resolve
+
+[Resolves](https://nodejs.org/docs/latest/api/path.html#path_path_resolve_paths) a sequence of paths or path segments into an absolute path.
+
+## symlink
+
+[Makes a symbolic link](https://github.com/szwacz/fs-jetpack#symlinksymlinkvalue-path) to a file or directory.
+
+## write
+
+[Writes](https://github.com/szwacz/fs-jetpack#writepath-data-options) data to a file.

--- a/ir-docs/toolbox-api/http.md
+++ b/ir-docs/toolbox-api/http.md
@@ -1,0 +1,32 @@
+# http
+
+Gives you the ability to talk to HTTP(s) web and API servers using [apisauce](https://github.com/skellock/apisauce) which
+is a thin wrapper around [axios](https://github.com/mzabriskie/axios).
+
+You can access these tools on the Gluegun toolbox, via `const { http } = require('gluegun')`, or directly via `const { http } = require('gluegun/http')`.
+
+## create
+
+This creates an `apisauce` client. It takes 1 parameter called `options` which is an object.
+
+```js
+const api = toolbox.http.create({
+  baseURL: 'https://api.github.com',
+  headers: { Accept: 'application/vnd.github.v3+json' },
+})
+```
+
+Once you have this api object, you can then call `HTTP` verbs on it. All verbs are `async` so don't forget your `await` call.
+
+```js
+// GET
+const { ok, data } = await api.get('/repos/skellock/apisauce/commits')
+
+// and others
+api.get('/repos/skellock/apisauce/commits')
+api.head('/me')
+api.delete('/users/69')
+api.post('/todos', { note: 'jump around' }, { headers: { 'x-ray': 'machine' } })
+api.patch('/servers/1', { live: false })
+api.put('/servers/1', { live: true })
+```

--- a/ir-docs/toolbox-api/index.md
+++ b/ir-docs/toolbox-api/index.md
@@ -1,0 +1,72 @@
+# Inside the Gluegun Toolbox
+
+Let's explore the inside of the famous Gluegun "Toolbox" (or "Context" as it's sometimes called).
+
+```js
+module.exports = {
+  name: 'dostuff',
+  alias: 'd',
+  run: async function (toolbox) {
+    // great! now what?
+  },
+}
+```
+
+Here's what's available inside the `toolbox` object you see all over Gluegun.
+
+| name               | provides the...                                    | 3rd party                      |
+| ------------------ | -------------------------------------------------- | ------------------------------ |
+| **meta**           | information about the currently running CLI        |                                |
+| **config**         | configuration options from the app or plugin       |                                |
+| **filesystem**     | ability to copy, move & delete files & directories | fs-jetpack                     |
+| **http**           | ability to talk to the web                         | apisauce                       |
+| **parameters**     | command line arguments and options                 | yargs-parser                   |
+| **patching**       | manipulating file contents easily                  | fs-jetpack                     |
+| **print**          | tools to print output to the command line          | colors, ora                    |
+| **prompt**         | tools to acquire extra command line user input     | enquirer                       |
+| **semver**         | utilities for working with semantic versioning     | semver                         |
+| **strings**        | some string helpers like case conversion, etc.     | lodash                         |
+| **system**         | ability to execute                                 | node-which, execa, cross-spawn |
+| **template**       | code generation from templates                     | ejs                            |
+| **packageManager** | ability to add or remove packages with Yarn/NPM    |                                |
+
+The `toolbox` has "drawers" full of useful tools for building CLIs. For example, the `toolbox.meta.version` function can
+be invoked like this:
+
+```js
+module.exports = {
+  name: 'dostuff',
+  alias: 'd',
+  run: async function (toolbox) {
+    // use them like this...
+    toolbox.print.info(toolbox.meta.version())
+
+    // or destructure!
+    const {
+      print: { info },
+      meta: { version },
+    } = toolbox
+    info(version())
+  },
+}
+```
+
+To learn more about each tool, explore the rest of the `toolbox-*.md` files in this folder.
+
+## Accessing Tools Directly
+
+You can access almost all of Gluegun's toolbox tools without running a command. This is useful when you'd like to use
+these tools outside a CLI context or when doing some really specialized CLI.
+
+```js
+const { print, filesystem, strings } = require('gluegun')
+// or
+const { print } = require('gluegun/print')
+const { filesystem } = require('gluegun/filesystem')
+const { strings } = require('gluegun/strings')
+const { packageManager } = require('gluegun/package-manager')
+
+print.info(`Hey, I'm Gluegun!`)
+filesystem.dir('/tmp/jamon')
+print.error(strings.isBlank(''))
+```

--- a/ir-docs/toolbox-api/package-manager.md
+++ b/ir-docs/toolbox-api/package-manager.md
@@ -1,0 +1,60 @@
+# packageManager
+
+Provides an API for intelligently running commands in yarn or npm depending on which is installed.
+
+## hasYarn
+
+Whether the current system has yarn installed
+
+```js
+toolbox.packageManager.hasYarn() // true
+```
+
+## add (async)
+
+Adds a package using yarn or npm
+
+```js
+await toolbox.packageManager.add('infinite_red', {
+  dev: true,
+  dryRun: false,
+  force: 'npm', //remove this to have the system determine which
+})
+```
+
+Will return an object similar to the following:
+
+```js
+{
+  success: true,
+  command: 'npm install --save-dev infinite_red',
+  stdout: ''
+}
+```
+
+You can also use an array with the package names you want to install to add it all at once.
+
+```js
+await toolbox.packageManager.add(['infinite_red', 'infinite_blue'], {
+  dev: true,
+  dryRun: false,
+```
+
+## remove (async)
+
+Removes a package using yarn or npm
+
+```js
+await toolbox.packageManager.remove('infinite_red', {
+  dryRun: false,
+  force: 'npm', //remove this to have the system determine which
+})
+```
+
+Like `add` function, you can also use an array to remove multiple packages.
+
+```js
+await toolbox.packageManager.remove(['infinite_red', 'infinite_blue'], {
+  dryRun: false,
+})
+```

--- a/ir-docs/toolbox-api/parameters.md
+++ b/ir-docs/toolbox-api/parameters.md
@@ -1,0 +1,78 @@
+# parameters
+
+Information about how the command was invoked. You can access this on the Gluegun toolbox. Check out this example of creating a new Reactotron plugin.
+
+```sh
+gluegun reactotron plugin MyAwesomePlugin full --comments --lint standard
+```
+
+| name        | type   | purpose                           | from the example above               |
+| ----------- | ------ | --------------------------------- | ------------------------------------ |
+| **plugin**  | string | the plugin used                   | `'reactotron'`                       |
+| **command** | string | the command used                  | `'plugin'`                           |
+| **string**  | string | the command arguments as a string | `'MyAwesomePlugin full'`             |
+| **array**   | array  | the command arguments as an array | `['MyAwesomePlugin', 'full']`        |
+| **first**   | string | the 1st argument                  | `'MyAwesomePlugin'`                  |
+| **second**  | string | the 2nd argument                  | `'full'`                             |
+| **third**   | string | the 3rd argument                  | `undefined`                          |
+| **options** | object | command line options              | `{comments: true, lint: 'standard'}` |
+| **argv**    | object | raw argv                          |                                      |
+
+## options
+
+Options are the command line flags. Always exists however it may be empty.
+
+```sh
+gluegun say hello --loud -v --wave furiously
+```
+
+```js
+module.exports = async function (toolbox) {
+  toolbox.parameters.options // { loud: true, v: true, wave: 'furiously' }
+}
+```
+
+## string
+
+Everything else after the command as a string.
+
+```sh
+gluegun say hello there
+```
+
+```js
+module.exports = async function (toolbox) {
+  toolbox.parameters.string // 'hello there'
+}
+```
+
+## array
+
+Everything else after the command, but as an array.
+
+```sh
+gluegun reactotron plugin full
+```
+
+```js
+module.exports = async function (toolbox) {
+  toolbox.parameters.array // ['plugin', 'full']
+}
+```
+
+## first / .second / .third
+
+The first, second, and third element in `array`. It is provided as a shortcut, and there isn't one,
+this will be `undefined`.
+
+```sh
+gluegun reactotron plugin full
+```
+
+```js
+module.exports = async function (toolbox) {
+  toolbox.parameters.first // 'plugin'
+  toolbox.parameters.second // 'full'
+  toolbox.parameters.third // undefined
+}
+```

--- a/ir-docs/toolbox-api/patching.md
+++ b/ir-docs/toolbox-api/patching.md
@@ -1,0 +1,93 @@
+# patching
+
+Tools to help adjust the contents of text files.
+
+You can access these tools on the Gluegun toolbox, via `const { patching } = require('gluegun')`, or directly via `const { patching } = require('gluegun/patching')`.
+
+## exists
+
+> This is an **async** function.
+
+Reads in a file and checks whether it's content matches a string or regular expression.
+
+```js
+// Case sensitive string match
+const barbExists = await toolbox.patching.exists('config.txt', 'Barb')
+
+// Short form regex
+const barbExists = await toolbox.patching.exists('config.txt', /Barb/)
+
+// Regex Object
+const barbExists = await toolbox.patching.exists('config.txt', new Regex(/Barb/, 'i'))
+```
+
+## update
+
+> This is an **async** function.
+
+Updates a given file by reading it in and then taking the result of the provided callback and writing it back to the config file.
+
+If the file ends in `.json`, it'll be read in as an object. Return the updated object to have it written back to the config.
+
+If the file doesn't end in `.json`, you'll receive a string. Return an updated string to write back to the file.
+
+```js
+await toolbox.patching.update('config.json', (config) => {
+  config.key = 'new value'
+  return config
+})
+
+await toolbox.patching.update('config.txt', (data) => {
+  return data.replace('Jamon', 'Boss')
+})
+```
+
+## append
+
+> This is an **async** function.
+
+Appends a string to the given file.
+
+```js
+await toolbox.patching.append('config.txt', 'Append this string\n')
+```
+
+## prepend
+
+> This is an **async** function.
+
+Prepends a string to the given file.
+
+```js
+await toolbox.patching.prepend('config.txt', 'Prepend this string\n')
+```
+
+## replace
+
+> This is an **async** function.
+
+Replaces a string in a given file.
+
+```js
+await toolbox.patching.replace('config.txt', 'Remove this string\n', 'Replace with this string\n')
+```
+
+## patch
+
+> This is an **async** function.
+
+Allows inserting next to, deleting, and replacing strings or regular expression in a given file. If `insert` is already present in the file, it won't change the file, unless you also pass through `force: true`.
+
+```js
+await toolbox.patching.patch('config.txt', { insert: 'Jamon', before: 'Something else' })
+await toolbox.patching.patch('config.txt', { insert: 'Jamon', after: 'Something else' })
+await toolbox.patching.patch('config.txt', { insert: 'Jamon', replace: 'Something else' })
+await toolbox.patching.patch('config.txt', { insert: 'Jamon', replace: 'Something else', force: true })
+await toolbox.patching.patch('config.txt', { delete: 'Something' })
+await toolbox.patching.patch('config.txt', { insert: 'Jamon', after: new RegExp('some regexp') })
+await toolbox.patching.patch(
+  'config.txt',
+  { insert: 'Jamon', after: 'Something else' },
+  { insert: 'Jamon', before: 'Something else' },
+)
+```

--- a/ir-docs/toolbox-api/print.md
+++ b/ir-docs/toolbox-api/print.md
@@ -1,0 +1,232 @@
+# print
+
+Features for allowing you to print to the console.
+
+You can access these tools on the Gluegun toolbox, via `const { print } = require('gluegun')`, or directly via `const { print } = require('gluegun/print')`.
+
+## info
+
+Prints an informational message. Use this as your goto.
+
+```js
+toolbox.print.info('Hello.  I am a chatty plugin.')
+```
+
+## success
+
+Print a "something good just happened" message.
+
+```js
+toolbox.print.success('We did it!')
+```
+
+## warning
+
+Prints a warning message. Use this when you feel a disturbance in the force.
+
+```js
+toolbox.print.warning("Your system does not have Yarn installed.  It's awesome.")
+```
+
+## error
+
+Prints an error message. Use this when something goes Pants-On-Head wrong. What does that mean?
+Well, if your next line of code isn't `process.exit(0)`, then it was probably a warning.
+
+```js
+toolbox.print.error('Out of disk space.  lol.')
+```
+
+## highlight
+
+Prints a message that's intended to have attention drawn to it.
+You could use it to point out the correct command to be run in an error message.
+Or you could use it to head sections of your help screen printout.
+
+```js
+toolbox.print.highlight('Run `gluegun login` to login')
+```
+
+## muted
+
+Prints a message in a muted gray color.
+This is useful for info that's not the most important but still helpful.
+Think of mundane or commonplace lines in output logging, for example.
+
+```js
+toolbox.print.muted('Connection status: GOOD')
+```
+
+## debug
+
+Only used for debugging your plugins. You can pass this function a string or an object.
+
+```js
+toolbox.print.debug(someObject, 'download status')
+```
+
+The `message` parameter is object you would like to see.
+
+The `title` is an optional title message which is handy if you've got a lot of debug messages and
+you're losing track of which one is which.
+
+## colors
+
+An object for working with printing colors on the command line. It is from the `colors` NPM package,
+however we define a theme to make things a bit consistent.
+
+Some available functions include:
+
+| function             | use when you want...                     |
+| -------------------- | ---------------------------------------- |
+| `colors.success()`   | the user to smile                        |
+| `colors.error()`     | to say something has failed              |
+| `colors.warning()`   | to point out that something might be off |
+| `colors.highlight()` | to draw attention to something           |
+| `colors.info()`      | to say something informational           |
+| `colors.muted()`     | you need to say something secondary      |
+
+Each take a `string` parameter and return a `string`.
+
+One gotcha here is that the length of the string is longer than you think because of the embedded
+color codes that disappear when you print them. 🔥
+
+## spin
+
+Creates a spinner for long running tasks on the command line. It's
+[ora](https://github.com/sindresorhus/ora)!
+
+Here's an example of how to work with it:
+
+```js
+// a spinner starts with the text you provide
+const spinner = toolbox.print.spin('Time for fun!')
+await toolbox.system.run('sleep 5')
+```
+
+🚨 Important 🚨 - Make sure you don't print anything else while a spinner is going. You need to stop
+it first.
+
+There's a few ways to stop it.
+
+```js
+// stop it & clear the text
+spinner.stop()
+
+// stop it, leave a checkmark, and optional new text
+spinner.succeed('woot!')
+
+// stop it, leave an X, and optional new text
+spinner.fail('womp womp.')
+
+// stop it, leave a custom label, and optional new text
+spinner.stopAndPersist({ symbol: '🚨', text: 'osnap!' })
+```
+
+Once stopped, you can start it again later.
+
+```js
+spinner.start()
+```
+
+You can change the color of the spinner by setting:
+
+```js
+spinner.color = 'cyan'
+```
+
+The text can also be set with the normal printing colors.
+
+```js
+spinner.text = toolbox.print.colors.green('i like trees')
+```
+
+## printHelp
+
+Prints a default help screen, consisting of the brand name, version, and `printCommands` output (next).
+
+```js
+const { printHelp } = toolbox.print
+printHelp(toolbox)
+```
+
+## printCommands
+
+Prints out a table of available commands in a given toolbox.
+
+```js
+const { printCommands } = toolbox.print
+printCommands(toolbox)
+```
+
+You can pass in a "command path" to refine what commands you'd like to see:
+
+```js
+const { printCommands } = toolbox.print
+printCommands(toolbox, ['generate', 'model'])
+```
+
+## table
+
+Prints out a table of data, including a header. You can choose from three different formats:
+`default`, `markdown`, and `lean`.
+
+```js
+const { table } = toolbox.print
+table(
+  [
+    ['First Name', 'Last Name', 'Age'],
+    ['Jamon', 'Holmgren', 35],
+    ['Gant', 'Laborde', 36],
+    ['Steve', 'Kellock', 43],
+    ['Gary', 'Busey', 73],
+  ],
+  { format: 'markdown' },
+)
+```
+
+Output:
+
+```
+| First Name | Last Name | Age |
+| ---------- | --------- | --- |
+| Jamon      | Holmgren  | 35  |
+| Gant       | Laborde   | 36  |
+| Steve      | Kellock   | 43  |
+| Gary       | Busey     | 73  |
+```
+
+You can also pass styles for the table (as specified in [cli-table3](https://github.com/cli-table/cli-table3)):
+
+```js
+const { table } = toolbox.print
+table(
+  [
+    ['First Name', 'Last Name', 'Age'],
+    ['Jamon', 'Holmgren', 35],
+    ['Gant', 'Laborde', 36],
+    ['Steve', 'Kellock', 43],
+    ['Gary', 'Busey', 73],
+  ],
+  {
+    format: 'lean',
+    style: { 'padding-left': 0, 'padding-right': 8 },
+  },
+)
+```
+
+Output:
+
+```
+┌──────────────────┬─────────────────┬───────────┐
+│First Name        │Last Name        │Age        │
+├──────────────────┼─────────────────┼───────────┤
+│Jamon             │Holmgren         │35         │
+├──────────────────┼─────────────────┼───────────┤
+│Gant              │Laborde          │36         │
+├──────────────────┼─────────────────┼───────────┤
+│Steve             │Kellock          │43         │
+├──────────────────┼─────────────────┼───────────┤
+│Gary              │Busey            │73         │
+└──────────────────┴─────────────────┴───────────┘
+```

--- a/ir-docs/toolbox-api/prompt.md
+++ b/ir-docs/toolbox-api/prompt.md
@@ -1,0 +1,147 @@
+# prompt
+
+Prompt allows you to ask the user for input.
+
+You can access these tools on the Gluegun toolbox, via `const { prompt } = require('gluegun')`, or directly via `const { prompt } = require('gluegun/prompt')`.
+
+## ask
+
+This is powered by [enquirer](https://github.com/enquirer/enquirer) (2.x).
+
+> This is an **async** function.
+
+#### example
+
+```js
+// text input
+const askAge = { type: 'input', name: 'age', message: 'How old are you?' }
+
+// multiple choice
+const askShoe = {
+  type: 'select',
+  name: 'shoe',
+  message: 'What shoes are you wearing?',
+  choices: ['Clown', 'Other'],
+}
+
+// ask a series of questions
+const questions = [askAge, askShoe]
+const { age, shoe } = await toolbox.prompt.ask(questions)
+```
+
+_Note: to see a full list of examples, scroll to the bottom._
+
+**Important: in order to preserve backwards compatibility with Enquirer 1.x, we
+translate `type: 'list'` to `type: 'select'`. If you want to use the new `list`
+behavior, please use `enquirer` directly and not through Gluegun.**
+
+## confirm
+
+> This is an **async** function.
+
+A pre-built prompt which asks a yes or no question.
+
+#### parameters
+
+- **message** is a `string` required for displaying a message to user. It's the question you're asking.
+- (optional) **initial** is a `boolean` for setting which answer is the default. `true` for Yes, `false` for No. Defaults to false.
+
+#### returns
+
+`true` or `false`
+
+#### example
+
+```js
+const isThe90s = await toolbox.prompt.confirm('Ya`ll ready for this?')
+```
+
+## separator
+
+Returns a separator you can use in your multiple choice prompts. It will draw a nice `--------` line and will not be able to be selected by the user.
+
+#### parameters
+
+- none
+
+#### returns
+
+A value only relevant for use in a multiple choice prompt.
+
+#### example
+
+```js
+const choices = ['red', 'green', toolbox.prompt.separator(), 'cheese', 'bread']
+```
+
+## Kitchen Sink Example
+
+Try running `gluegun kitchen` to see what these look like.
+
+```typescript
+import { prompt, GluegunToolbox } from 'gluegun'
+
+module.exports = {
+  name: 'kitchen',
+  description: 'Runs through a kitchen sink of Gluegun tools',
+  run: async (toolbox: GluegunToolbox) => {
+    const { print } = toolbox
+
+    const result = await prompt.ask([
+      {
+        type: 'select',
+        name: 'exselect',
+        message: 'What shoes are you wearing?',
+        choices: ['Clown', 'Other'],
+      },
+      {
+        type: 'confirm',
+        name: 'exconfirm',
+        message: 'Are you sure?',
+      },
+      {
+        type: 'multiselect',
+        name: 'exmultiselect',
+        message: 'What are your favorite colors?',
+        choices: ['red', 'blue', 'yellow'],
+      },
+      {
+        type: 'select',
+        name: 'exselect',
+        message: 'What is your favorite team?',
+        choices: ['Jazz', 'Trail Blazers', 'Lakers', 'Warriors'],
+      },
+      {
+        type: 'multiselect',
+        name: 'exmultiselect',
+        message: 'What are your favorite months?',
+        choices: ['January', 'July', 'September', 'November'],
+      },
+      {
+        type: 'password',
+        name: 'expassword',
+        message: 'Enter a fake password',
+      },
+      {
+        type: 'input',
+        name: 'exinput',
+        message: 'What is your middle name?',
+      },
+      {
+        type: 'autocomplete',
+        name: 'exautocomplete',
+        message: 'State?',
+        choices: ['Oregon', 'Washington', 'California'],
+        // You can leave this off unless you want to customize behavior
+        suggest(s, choices) {
+          return choices.filter((choice) => {
+            return choice.message.toLowerCase().startsWith(s.toLowerCase())
+          })
+        },
+      },
+    ])
+
+    print.debug(result)
+  },
+}
+```

--- a/ir-docs/toolbox-api/semver.md
+++ b/ir-docs/toolbox-api/semver.md
@@ -1,0 +1,23 @@
+# semver
+
+A set of functions & values to work with semantic versions. The majority of these functions come
+straight from [semver](https://github.com/npm/node-semver)
+
+You can access these tools on the Gluegun toolbox, via `const { semver } = require('gluegun')`, or directly via `const { semver } = require('gluegun/semver')`.
+
+## Usage
+
+All your common semver needs are accessible.
+
+```js
+// Step 1: grab from toolbox
+const semver = { toolbox }
+
+// Step 2: start using
+semver.valid('1.2.3') // '1.2.3'
+semver.valid('a.b.c') // null
+semver.clean('  =v1.2.3   ') // '1.2.3'
+semver.satisfies('1.2.3', '1.x || >=2.5.0 || 5.0.0 - 7.2.3') // true
+semver.gt('1.2.3', '9.8.7') // false
+semver.lt('1.2.3', '9.8.7') // true
+```

--- a/ir-docs/toolbox-api/strings.md
+++ b/ir-docs/toolbox-api/strings.md
@@ -1,0 +1,338 @@
+# strings
+
+Provides some helper functions to work with strings. This list is also added to the available filters
+inside your EJS templates.
+
+You can access these tools on the Gluegun toolbox, via `const { strings } = require('gluegun')`, or directly via `const { strings } = require('gluegun/strings')`.
+
+---
+
+## **Utility**
+
+## identity
+
+Returns the **input** as **output**. Great for functional programming like sorting or fallbacks.
+
+** arguments **
+
+- `value` can be `any` type which becomes the return value of this function.
+
+** returns **
+
+- the `value` that was passed in
+
+```js
+identity('hello') // hello
+identity(4) // 4
+identity([1, 'a']) // [1, 'a']
+```
+
+## isBlank
+
+Determines if a string is empty by trimming it first.
+
+```js
+isBlank('') // true
+isBlank('   ') // true
+```
+
+## isNotString
+
+Tests a value to see if it is not a string.
+
+```js
+isNotString(true) // true
+isNotString(null) // true
+isNotString(undefined) // true
+isNotString(123) // true
+isNotString('hi') // false
+```
+
+---
+
+## **Growing**
+
+## pad
+
+Centers a string to a given length.
+
+```js
+pad('hola', 20) // '        hola        '
+```
+
+## padStart
+
+Fills a string to a certain length by adding characters to the front.
+
+```js
+padStart('hello', 10, '.') // '.....hello'
+```
+
+## padEnd
+
+Fills a string to a certain length by adding characters to the end.
+
+```js
+padEnd('hello', 10, '!') // 'hello!!!!!'
+```
+
+## repeat
+
+Repeats a string a number of times to make a pattern.
+
+```js
+repeat('x', 3) // 'xxx'
+repeat('xo', 3) // 'xoxoxo'
+```
+
+---
+
+## **Shrinking**
+
+## trim
+
+Strips white space from both the start and end of a string, but not the middle.
+
+```js
+trim('    kevin   spacey    ') // 'kevin   spacey'
+```
+
+## trimStart
+
+Strips white space from the start of a string.
+
+```js
+trimStart('          hi ') // 'hi '
+```
+
+## trimEnd
+
+Strips white space from the end of a string.
+
+```js
+trimEnd('windows!\r\n') // 'windows!'
+```
+
+---
+
+## **Case Conversion**
+
+## camelCase
+
+Capitalizes the first letter of each word it smashes together on word boundaries. The first letter becomes lowercase. Puncuation gets dropped.
+
+Great for assembling javascript variable names.
+
+```js
+camelCase('hello there') // 'helloThere'
+camelCase('Hello there') // 'helloThere'
+camelCase('abc123') // 'abc123'
+camelCase('Y M C A') // 'yMCA'
+camelCase('Welcome to ZOMBO.com') // 'welcomeToZomboCom'
+camelCase('XMLHttpRequest is strange.') // 'xmlHttpRequestIsStrange'
+camelCase('OSnap') // 'oSnap'
+camelCase('this.is.sparta!') // 'thisIsSparta'
+```
+
+## kebabCase
+
+Skewers words by placing - characters between them and downcasing.
+
+```js
+kebabCase('hello there') // 'hello-there'
+kebabCase('Hello there') // 'hello-there'
+kebabCase('abc123') // 'abc-123'
+kebabCase('Y M C A') // 'y-m-c-a'
+kebabCase('Welcome to ZOMBO.com') // 'welcome-to-zombo-com'
+kebabCase('XMLHttpRequest is strange.') // 'xml-http-request-is-strange'
+kebabCase('OSnap') // 'o-snap'
+kebabCase('this.is.sparta!') // 'this-is-sparta'
+```
+
+## snakeCase
+
+Joins words together with underscores after splitting up into word boundaries.
+
+Great for ruby and some apis.
+
+```js
+snakeCase('hello there') // 'hello_there'
+snakeCase('Hello there') // 'hello_there'
+snakeCase('abc123') // 'abc_123'
+snakeCase('Y M C A') // 'y_m_c_a'
+snakeCase('Welcome to ZOMBO.com') // 'welcome_to_zombo_com'
+snakeCase('XMLHttpRequest is strange.') // 'xml_http_request_is_strange'
+snakeCase('OSnap') // 'o_snap'
+snakeCase('this.is.sparta!') // 'this_is_sparta'
+```
+
+## upperCase
+
+A staple in every troll's toolbelt, this makes everything uppercase.
+
+```js
+upperCase('hello there') // 'HELLO THERE'
+upperCase('Hello there') // 'HELLO THERE'
+upperCase('abc123') // 'ABC 123'
+upperCase('Y M C A') // 'Y M C A'
+upperCase('Welcome to ZOMBO.com') // 'WELCOME TO ZOMBO COM'
+upperCase('XMLHttpRequest is strange.') // 'XML HTTP REQUEST IS STRANGE'
+upperCase('OSnap') // 'O SNAP'
+upperCase('this.is.sparta!') // 'THIS IS SPARTA'
+```
+
+## lowerCase
+
+This makes everything lower case.
+
+```js
+lowerCase('hello there') // 'hello there'
+lowerCase('Hello there') // 'hello there'
+lowerCase('abc123') // 'abc 123'
+lowerCase('Y M C A') // 'y m c a'
+lowerCase('Welcome to ZOMBO.com') // 'welcome to zombo com'
+lowerCase('XMLHttpRequest is strange.') // 'xml http request is strange'
+lowerCase('OSnap') // 'o snap'
+lowerCase('this.is.sparta!') // 'this is sparta'
+```
+
+## startCase
+
+Uppercases the first letter of each word after dicing up on word boundaries.
+
+```js
+startCase('hello there') // 'Hello There'
+startCase('Hello there') // 'Hello There'
+startCase('abc123') // 'Abc 123'
+startCase('Y M C A') // 'Y M C A'
+startCase('Welcome to ZOMBO.com') // 'Welcome To ZOMBO Com'
+startCase('XMLHttpRequest is strange.') // 'XML Http Request Is Strange'
+startCase('OSnap') // 'O Snap'
+startCase('this.is.sparta!') // 'This Is Sparta'
+```
+
+## upperFirst
+
+Uppercases the first letter of the string.
+
+```js
+upperFirst('hello there') // 'Hello there'
+upperFirst('Hello there') // 'Hello there'
+upperFirst('abc123') // 'Abc123'
+upperFirst('Y M C A') // 'Y M C A'
+upperFirst('Welcome to ZOMBO.com') // 'Welcome to ZOMBO.com'
+upperFirst('XMLHttpRequest is strange.') // 'XMLHttpRequest is strange.'
+upperFirst('OSnap') // 'OSnap'
+upperFirst('this.is.sparta!') // 'This.is.sparta!'
+```
+
+## lowerFirst
+
+Lowercases the first letter of the string.
+
+```js
+lowerFirst('hello there') // 'hello there'
+lowerFirst('Hello there') // 'hello there'
+lowerFirst('abc123') // 'abc123'
+lowerFirst('Y M C A') // 'y M C A'
+lowerFirst('Welcome to ZOMBO.com') // 'welcome to ZOMBO.com'
+lowerFirst('XMLHttpRequest is strange.') // 'xMLHttpRequest is strange.'
+lowerFirst('OSnap') // 'oSnap'
+lowerFirst('this.is.sparta!') // 'this.is.sparta!'
+```
+
+## pascalCase
+
+This is `camelCase` + `upperFirst`.
+
+```js
+pascalCase('hello there') // 'HelloThere'
+pascalCase('Hello there') // 'HelloThere'
+pascalCase('abc123') // 'Abc123'
+pascalCase('Y M C A') // 'YMCA'
+pascalCase('Welcome to ZOMBO.com') // 'WelcomeToZomboCom'
+pascalCase('XMLHttpRequest is strange.') // 'XmlHttpRequestIsStrange'
+pascalCase('OSnap') // 'OSnap'
+pascalCase('this.is.sparta!') // 'ThisIsSparta'
+```
+
+## pluralize
+
+Pluralize or singularize a word based on the passed in count.
+
+```
+pluralize('test', 1) // 'test'
+pluralize('test', 5) // 'tests'
+pluralize('test', 1, true) // '1 test'
+pluralize('test', 5, true) // '5 tests'
+```
+
+## plural
+
+Converts a given singular word to plural.
+
+```
+plural('bug') // 'bugs'
+plural('word') // 'words'
+```
+
+## singular
+
+Converts a given plural word to singular.
+
+```
+singular('bugs') // 'bug'
+singular('words') // 'word'
+```
+
+## isPlural
+
+Checks if the give word is plural.
+
+```
+isPlural('bugs') // true
+isPlural('bug') // false
+```
+
+## isSingular
+
+Checks if the give word is singular.
+
+```
+isSingular('bugs') // false
+isSingular('bug') // true
+```
+
+## addPluralRule
+
+Adds a pluralization rule for the given singular word when calling plural.
+
+```
+addPluralRule('regex', 'regexii')
+addPluralRule(/regex$/, 'regexii')
+```
+
+## addSingularRule
+
+Adds a pluralization rule for the given plural word when calling singular.
+
+```
+addSingularRule('regexii', 'regex')
+addSingularRule(/regexii$/, 'regex')
+```
+
+## addIrregularRule
+
+Adds a pluralization rule for the given irregular word when calling plural.
+
+```
+addIrregularRule('octopus', 'octopodes')
+```
+
+## addUncountableRule
+
+Exempts the given uncountable word from pluralization so that calling plural or singular with that word will return the same word unchanged.
+
+```
+addUncountableRule('paper')
+```

--- a/ir-docs/toolbox-api/system.md
+++ b/ir-docs/toolbox-api/system.md
@@ -1,0 +1,60 @@
+# system
+
+Provides access to shell and OS processes.
+
+You can access these tools on the Gluegun toolbox, via `const { system } = require('gluegun')`, or directly via `const { system } = require('gluegun/system')`.
+
+## run
+
+> This is an **async** function.
+
+Runs a shell command and returns the output as a string.
+
+The first parameter `commandLine` is the shell command to run. It can have pipes! The
+second parameter is `options`, object. This is a promise wrapped around node.js `child-process.exec`
+[api call](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback).
+
+You can also pass `trim: true` inside the options parameter to have the output automatically trim all
+starting and trailing spaces.
+
+Should the process fail, an `error` will be thrown with properties such as:
+
+| property | type   | purpose                                               |
+| -------- | ------ | ----------------------------------------------------- |
+| code     | number | the exit code                                         |
+| cmd      | string | the command we asked to run                           |
+| stdout   | string | any information the process wrote to `stdout`         |
+| stderr   | string | any information the process wrote to `stderr`         |
+| killed   | bool   | if the process was killed or not                      |
+| signal   | number | the signal number used to off the process (if killed) |
+
+```js
+const nodeVersion = toolbox.system.run('node -v', { trim: true })
+```
+
+### toolbox.system.which
+
+Returns the full path to a command on your system if located on your path.
+
+```js
+const whereIsIt = toolbox.system.which('npm')
+```
+
+### toolbox.system.open
+
+:(
+
+### toolbox.system.startTimer
+
+Starts a timer for... well... timing stuff. `startTimer()` returns a function. When this is called, the number of milliseconds will be returned.
+
+```js
+const timer = toolbox.system.startTimer()
+
+// time passes...
+console.log(`that just took ${timer()} ms.`)
+```
+
+Caveat: Due to the event loop scheduler in Node.JS, they don't guarantee millisecond accuracy when invoking async functions. For that reason, expect a up to a 4ms overage.
+
+Note that this lag doesn't apply to synchronous code.

--- a/ir-docs/toolbox-api/template.md
+++ b/ir-docs/toolbox-api/template.md
@@ -1,0 +1,41 @@
+# template
+
+Features for generating files based on a template. You can access these tools on the Gluegun toolbox.
+
+## generate
+
+> This is an **async** function.
+
+Generates a new file based on a template.
+
+#### example
+
+```js
+module.exports = async function (toolbox) {
+  const name = toolbox.parameters.first
+
+  await toolbox.template.generate({
+    template: 'component.ejf',
+    target: `app/components/${name}-view.js`,
+    props: { name },
+  })
+}
+```
+
+In the EJS template, you will use the props object to get the data defined previously.
+
+```ejs
+<title><%= props.name %></title>
+```
+
+Note: `generate()` will always overwrite the target if given. Make sure to prompt your users if that's
+the behaviour you're after.
+
+| option      | type   | purpose                              | notes                                        |
+| ----------- | ------ | ------------------------------------ | -------------------------------------------- |
+| `template`  | string | path to the EJS template             | relative from plugin's `templates` directory |
+| `target`    | string | path to create the file              | relative from user's working directory       |
+| `props`     | object | more data to render in your template |                                              |
+| `directory` | string | where to find templates              | an absolute path (optional)                  |
+
+`generate()` returns the string that was generated in case you didn't want to render to a target.

--- a/ir-docs/tutorials/_category_.json
+++ b/ir-docs/tutorials/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Guides",
+  "position": 600,
+  "link": {
+    "type": "generated-index",
+    "description": "Tutorials to get you started"
+  }
+}

--- a/ir-docs/tutorials/tutorial-making-a-movie-cli.md
+++ b/ir-docs/tutorials/tutorial-making-a-movie-cli.md
@@ -2,7 +2,7 @@
 
 _You can see the latest version of the result of this tutorial on Github at [https://github.com/infinitered/tutorial-movie](https://github.com/infinitered/tutorial-movie)!_
 
-In this tutorial, we'll make a Gluegun-powered command-line interface called `movie`. Before doing this tutorial, make sure you've followed the installation instructions in [Getting Started](../getting-started). We will also be using [yarn](https://yarnpkg.com/) in this tutorial rather than `npm`. You can use `npm` if you want.
+In this tutorial, we'll make a Gluegun-powered command-line interface called `movie`. Before doing this tutorial, make sure you've followed the installation instructions in [Getting Started](/getting-started). We will also be using [yarn](https://yarnpkg.com/) in this tutorial rather than `npm`. You can use `npm` if you want.
 
 ## Generate a new CLI
 

--- a/ir-docs/tutorials/tutorial-making-a-plugin.md
+++ b/ir-docs/tutorials/tutorial-making-a-plugin.md
@@ -1,0 +1,140 @@
+# Making a plugin for your Gluegun-powered CLI
+
+Gluegun is a powerful CLI toolbox, but if you want to know what really sets it apart, it's the plugin system. While Commander and Yeoman and other CLI systems have plugin concepts, with gluegun we treat them as first-class citizens.
+
+Let's walk through creating a plugin for a CLI. We'll then use this plugin in a project where we're using this CLI.
+
+_Note: if you're experiencing any issues in the tutorial, feel free to let us know in the [IR Community Slack](https://community.infinite.red)_. We want this to work really smoothly!
+
+## Step 1: Our CLI
+
+We're building out a CLI that prints out system information, called `intern`. Let's spin this up:
+
+```bash
+$ yarn global add gluegun
+$ gluegun new intern --javascript
+$ cd intern
+$ yarn
+$ yarn link
+$ cd ..
+$ intern help
+```
+
+You should see the baked-in help for our new CLI. Yay!
+
+## Step 2: Create the basic plugin structure
+
+Let's create a plugin that we would use to show system information for macOS. It'll be called `intern-macos`.
+
+NOTE: This is the naming scheme we recommend for gluegun-powered plugins -- put the name of your CLI, a dash, and then the name of your plugin. Examples: `ignite-i18n`, `solidarity-react-native`. We support this naming scheme right out of the box, in fact!
+
+```bash
+$ mkdir intern-macos
+$ cd intern-macos
+$ yarn init
+```
+
+At this point, go through yarn's init. It doesn't matter too much what you put here. I just hit enter on everything.
+
+Lastly, add a `commands` and an `extensions` folder. Note that with new versions of Gluegun, you can also use a build pipeline and include your commands and extensions in `build/commands` and `build/extensions` and Gluegun will still find them.
+
+```bash
+$ mkdir commands extensions
+```
+
+## Step 3: Create a command
+
+We're going to make a command that we'll invoke with `intern macos` which will display the version of macOS we're currently running.
+
+```bash
+$ touch commands/macos.js
+```
+
+Open this file, and put the following:
+
+```js
+module.exports = {
+  name: 'macos',
+  alias: 'osx',
+  run: async ({ system, print }) => {
+    const osInfo = await system.run(`defaults read loginwindow SystemVersionStampAsString`)
+    print.info(osInfo)
+  },
+}
+```
+
+## Step 4: Create an extension
+
+While the above is a simple command, if the logic started getting more complex, we'd probably want to move it into an extension. Let's do that here.
+
+In `extensions`, create a new file called `macos-extension.js`:
+
+```bash
+$ touch extensions/macos-extension.js
+```
+
+Edit this file like so:
+
+```js
+module.exports = (toolbox) => {
+  toolbox.internMac = async () => {
+    return await toolbox.system.run(`defaults read loginwindow SystemVersionStampAsString`)
+  }
+}
+```
+
+This adds a new property to gluegun's awesome `toolbox` object, called `internMac`, which is a function that returns the info we need. Since all extensions are loaded automatically, it's available in our command, so let's use it in `commands/macos.js`:
+
+```js
+module.exports = {
+  name: 'macos',
+  alias: 'osx',
+  run: async ({ print, internMac }) => print.info(await internMac()),
+}
+```
+
+## Step 5: Make a new project
+
+Let's try this out!
+
+```bash
+cd ..
+mkdir my-project
+cd my-project
+yarn init
+yarn add ../intern-macos
+```
+
+Note that we're referencing the plugin from a folder, because we haven't published it to NPM yet. If we have, we'd use `yarn add intern-macos` like you'd expect.
+
+Now let's kick off our plugin command:
+
+```bash
+$ intern macos
+10.13.1
+```
+
+Let's try the alias:
+
+```bash
+$ intern macos osx
+10.13.1
+```
+
+Yay!
+
+## Step 6: Publish to NPM
+
+You can learn how to publish an NPM package here: [https://docs.npmjs.com/getting-started/publishing-npm-packages](https://docs.npmjs.com/getting-started/publishing-npm-packages)
+
+Once it's published, you can add your new plugin to your project:
+
+```bash
+$ yarn add intern-macos
+```
+
+After that, the new command should be available on your project like we explored above.
+
+_Still have questions? Let us know in the [IR Community Slack](https://community.infinite.red)._
+
+If you'd like to learn more about what plugins are, check out the [plugins documentation](./plugins.md).


### PR DESCRIPTION
Reorganize and convert documentation to work with new unified IR docusaurus site:

* Creates ir-docs folder
* Organizes docs in folders matching current sidebar
* Adds CI scripts 
    * pnly manually-triggered script is active
    * commented out others to prevent build failures from blocking other PRs if this gets merged.
* Creates an `./ir-docs/` folder with the new documentation, this will allow the existing documentation to remain up while we make the transition. When the new docs are ready we can simply rename the folder and point the CI at it.
* Updates internal links to be relative
* Creates metadata files for categories etc.
